### PR TITLE
InverseDocumentFrequencyEstimator

### DIFF
--- a/src/Featurizers/Components/InverseDocumentFrequencyEstimator.h
+++ b/src/Featurizers/Components/InverseDocumentFrequencyEstimator.h
@@ -7,11 +7,12 @@
 #include <unordered_map>
 #include <set>
 
-#include "Components/TrainingOnlyEstimatorImpl.h"
+#include "TrainingOnlyEstimatorImpl.h"
 
 namespace Microsoft {
 namespace Featurizer {
 namespace Featurizers {
+namespace Components {
 
 namespace {
 
@@ -227,6 +228,7 @@ InverseDocumentFrequencyAnnotationData Details::InverseDocumentFrequencyTraining
     return InverseDocumentFrequencyAnnotationData(std::move(_inverseDocumentFrequency), std::move(_totalNumDocuments));
 }
 
+} // namespace Components
 } // namespace Featurizers
 } // namespace Featurizer
 } // namespace Microsoft

--- a/src/Featurizers/Components/UnitTests/CMakeLists.txt
+++ b/src/Featurizers/Components/UnitTests/CMakeLists.txt
@@ -30,6 +30,7 @@ foreach(_test_name IN ITEMS
     HistogramEstimator_UnitTest
     IndexMapEstimator_UnitTest
     InferenceOnlyFeaturizerImpl_UnitTest
+    InverseDocumentFrequencyEstimator_UnitTests
     MaxAbsValueEstimator_UnitTest
     MinMaxEstimator_UnitTest
     ModeEstimator_UnitTest

--- a/src/Featurizers/Components/UnitTests/InverseDocumentFrequencyEstimator_UnitTests.cpp
+++ b/src/Featurizers/Components/UnitTests/InverseDocumentFrequencyEstimator_UnitTests.cpp
@@ -5,15 +5,15 @@
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
-#include "../../3rdParty/optional.h"
-#include "../TestHelpers.h"
+#include "../../../3rdParty/optional.h"
+#include "../../TestHelpers.h"
 #include "../InverseDocumentFrequencyEstimator.h"
 
 namespace NS = Microsoft::Featurizer;
 
 void TestString (std::string const & input, std::vector<std::string> const & label) {
     std::vector<std::string> predict;
-    NS::Featurizers::split_temp( 
+    NS::Featurizers::Components::split_temp( 
         input, 
         [&predict] (std::string::const_iterator & iter_start, std::string::const_iterator & iter_end) {
             std::string word = std::string(iter_start, iter_end);
@@ -23,26 +23,28 @@ void TestString (std::string const & input, std::vector<std::string> const & lab
     CHECK(predict == label);
 }
 
-NS::Featurizers::InverseDocumentFrequencyAnnotationData::InverseDocumentFrequency Test(std::vector<std::vector<std::string>> const &inputBatches) {
+NS::Featurizers::Components::InverseDocumentFrequencyAnnotationData::InverseDocumentFrequency Test(std::vector<std::vector<std::string>> const &inputBatches) {
     NS::AnnotationMapsPtr                                                   pAllColumnAnnotations(NS::CreateTestAnnotationMapsPtr(1));
-    NS::Featurizers::InverseDocumentFrequencyEstimator<std::numeric_limits<size_t>::max()>        
+    NS::Featurizers::Components::InverseDocumentFrequencyEstimator<std::numeric_limits<size_t>::max()>        
                                                                             estimator(pAllColumnAnnotations, 0);
 
     NS::TestHelpers::Train(estimator, inputBatches);
 
-    NS::Featurizers::InverseDocumentFrequencyAnnotationData     const &     annotation(estimator.get_annotation_data());
+    NS::Featurizers::Components::InverseDocumentFrequencyAnnotationData const &     
+                                                                            annotation(estimator.get_annotation_data());
 
     return annotation.TermFrequency;
 }
 
 std::uint32_t TestNum(std::vector<std::vector<std::string>> const &inputBatches) {
     NS::AnnotationMapsPtr                                                   pAllColumnAnnotations(NS::CreateTestAnnotationMapsPtr(1));
-    NS::Featurizers::InverseDocumentFrequencyEstimator<std::numeric_limits<size_t>::max()>            
+    NS::Featurizers::Components::InverseDocumentFrequencyEstimator<std::numeric_limits<size_t>::max()>            
                                                                             estimator(pAllColumnAnnotations, 0);
 
     NS::TestHelpers::Train(estimator, inputBatches);
 
-    NS::Featurizers::InverseDocumentFrequencyAnnotationData const &         annotation(estimator.get_annotation_data());
+    NS::Featurizers::Components::InverseDocumentFrequencyAnnotationData const &         
+                                                                            annotation(estimator.get_annotation_data());
 
     return annotation.TotalNumDocuments;
 }
@@ -68,7 +70,7 @@ TEST_CASE("string_split") {
 }
 
 TEST_CASE("string_idf") {
-    using InverseDocumentFrequency                         = NS::Featurizers::InverseDocumentFrequencyAnnotationData::InverseDocumentFrequency;
+    using InverseDocumentFrequency                         = NS::Featurizers::Components::InverseDocumentFrequencyAnnotationData::InverseDocumentFrequency;
 
     InverseDocumentFrequency const                         label({{"orange",3}, {"apple", 1}, {"peach", 3}, {"grape", 2}, {"banana",1}});
     std::vector<std::vector<std::string>> const            inputBatches({{" orange  apple  apple peach  grape "},
@@ -80,7 +82,7 @@ TEST_CASE("string_idf") {
 }
 
 TEST_CASE("string_idf_single_appearance") {
-    using InverseDocumentFrequency                         = NS::Featurizers::InverseDocumentFrequencyAnnotationData::InverseDocumentFrequency;
+    using InverseDocumentFrequency                         = NS::Featurizers::Components::InverseDocumentFrequencyAnnotationData::InverseDocumentFrequency;
 
     InverseDocumentFrequency const                         label({{"orange", 1}, {"apple", 1}, {"grape", 1}});
     std::vector<std::vector<std::string>> const            inputBatches({{" apple apple  apple"},
@@ -92,7 +94,7 @@ TEST_CASE("string_idf_single_appearance") {
 }
 
 TEST_CASE("string_idf_full_appearance") {
-    using InverseDocumentFrequency                         = NS::Featurizers::InverseDocumentFrequencyAnnotationData::InverseDocumentFrequency;
+    using InverseDocumentFrequency                         = NS::Featurizers::Components::InverseDocumentFrequencyAnnotationData::InverseDocumentFrequency;
 
     InverseDocumentFrequency const                         label({{"orange", 3}, {"apple", 3}, {"grape", 3}});
     std::vector<std::vector<std::string>> const            inputBatches({{"apple  grape orange  "},
@@ -104,7 +106,7 @@ TEST_CASE("string_idf_full_appearance") {
 }
 
 TEST_CASE("string_num") {
-    using InverseDocumentFrequency                         = NS::Featurizers::InverseDocumentFrequencyAnnotationData::InverseDocumentFrequency;
+    using InverseDocumentFrequency                         = NS::Featurizers::Components::InverseDocumentFrequencyAnnotationData::InverseDocumentFrequency;
 
     InverseDocumentFrequency const                         label({{"orange",3}, {"apple", 1}, {"peach", 3}, {"grape", 2}, {"banana",1}});
     std::vector<std::vector<std::string>> const            inputBatches({{"orange apple apple peach grape"},

--- a/src/Featurizers/UnitTests/CMakeLists.txt
+++ b/src/Featurizers/UnitTests/CMakeLists.txt
@@ -33,7 +33,6 @@ foreach(_test_name IN ITEMS
     DateTimeFeaturizer_UnitTests
     HashOneHotVectorizerFeaturizer_UnitTests
     ImputationMarkerFeaturizer_UnitTests
-    InverseDocumentFrequencyEstimator_UnitTests
     LabelEncoderFeaturizer_UnitTests
     MaxAbsScalarFeaturizer_UnitTests
     MinMaxScalarFeaturizer_UnitTests


### PR DESCRIPTION
An Estimator that will be used both in CountVectorizer and TfidfVectorizer by bundling the Idf information and total number of documents to annotation.
note: the string parsing function(split_temp in anonymous ns) is temporary will be removed after the following todo is done
todo: implementation of featurizerImpl in another file and use that to call functionality in strings.h