### PR TITLE
MatrixDecompositionEstimator

### DIFF
--- a/src/Featurizers/Components/MatrixDecompositionEstimator.h
+++ b/src/Featurizers/Components/MatrixDecompositionEstimator.h
@@ -15,7 +15,7 @@ static constexpr char const * const         MatrixDecompositionEstimatorName("Ma
 
 /////////////////////////////////////////////////////////////////////////
 ///  \class         MatrixDecompositionAnnotationData
-///  \brief         Contains an MatrixDecomposition 
+///  \brief         Contains 
 ///
 template <typename T>
 class MatrixDecompositionAnnotationData {
@@ -25,8 +25,8 @@ public:
     // |  Public Types
     // |
     // ----------------------------------------------------------------------
-    using SingularValueType                          = T;
-    using SingularVectorType                         = std::vector<SingularValueType>;
+    using SingularValueType                          = std::vector<T>;
+    using SingularVectorType                         = std::vector<std::vector<T>>;
 
     // ----------------------------------------------------------------------
     // |
@@ -63,22 +63,25 @@ public:
     // |
     // ----------------------------------------------------------------------
     using InputType                                  = T;
-    using SingularValueType                          = InputType;
-    using SingularVectorType                         = std::vector<SingularValueType>;
-    using MatrixType                                 = SingularVectorType;
+    using SingularValueType                          = std::vector<T>;
+    using SingularVectorType                         = std::vector<std::vector<T>>;
+    using MatrixType                                 = std::vector<T>;
     // ----------------------------------------------------------------------
     // |
     // |  Public Data
     // |
     // ----------------------------------------------------------------------
     static constexpr char const * const     NameValue = MatrixDecompositionEstimatorName;
-
+    enum DecompositionMethod {
+        SVD = 0,
+        PCA = 1
+    };
     // ----------------------------------------------------------------------
     // |
     // |  Public Methods
     // |
     // ----------------------------------------------------------------------
-    MatrixDecompositionTrainingOnlyPolicy(std::string mode);
+    MatrixDecompositionTrainingOnlyPolicy(DecompositionMethod method, size_t numRows);
 
     void fit(InputType const &input);
     MatrixDecompositionAnnotationData<T> complete_training(void);
@@ -91,11 +94,12 @@ private:
     // ----------------------------------------------------------------------
     MatrixType                                       _matrix;
 
-    SingularValueType const                          _sigma;
-    SingularVectorType const                         _u;
-    SingularVectorType const                         _v;
+    SingularValueType                                _sigma;
+    SingularVectorType                               _u;
+    SingularVectorType                               _v;
 
-    std::string const                                _mode;
+    DecompositionMethod const                        _method;
+    size_t const                                     _numRows;
 };
 
 } // namespace Details
@@ -125,13 +129,14 @@ public:
             Details::MatrixDecompositionTrainingOnlyPolicy<T>,
             MaxNumTrainingItemsV
         >;
+    using DecompositionMethod = typename Details::MatrixDecompositionTrainingOnlyPolicy<T>::DecompositionMethod;
 
     // ----------------------------------------------------------------------
     // |
     // |  Public Methods
     // |
     // ----------------------------------------------------------------------
-    MatrixDecompositionEstimator(AnnotationMapsPtr pAllColumnAnnotations, size_t colIndex, std::string mode);
+    MatrixDecompositionEstimator(AnnotationMapsPtr pAllColumnAnnotations, size_t colIndex, DecompositionMethod method, size_t numRows);
     ~MatrixDecompositionEstimator(void) override = default;
 
     FEATURIZER_MOVE_CONSTRUCTOR_ONLY(MatrixDecompositionEstimator);
@@ -166,8 +171,8 @@ MatrixDecompositionAnnotationData<T>::MatrixDecompositionAnnotationData(Singular
 // |
 // ----------------------------------------------------------------------
 template <typename T, size_t MaxNumTrainingItemsV>
-MatrixDecompositionEstimator<T, MaxNumTrainingItemsV>::MatrixDecompositionEstimator(AnnotationMapsPtr pAllColumnAnnotations, size_t colIndex, std::string mode) :
-    BaseType(std::move(pAllColumnAnnotations), std::move(colIndex), true, std::move(mode)) {
+MatrixDecompositionEstimator<T, MaxNumTrainingItemsV>::MatrixDecompositionEstimator(AnnotationMapsPtr pAllColumnAnnotations, size_t colIndex, DecompositionMethod method, size_t numRows) :
+    BaseType(std::move(pAllColumnAnnotations), std::move(colIndex), true, std::move(method), std::move(numRows)) {
 }
 
 // ----------------------------------------------------------------------
@@ -176,17 +181,10 @@ MatrixDecompositionEstimator<T, MaxNumTrainingItemsV>::MatrixDecompositionEstima
 // |
 // ----------------------------------------------------------------------
 template <typename T>
-Details::MatrixDecompositionTrainingOnlyPolicy<T>::MatrixDecompositionTrainingOnlyPolicy(std::string mode) :
-    _mode(
-        std::move(
-            [&mode](void) -> std::string & {
-                if(mode != "svd" && mode != "pca")
-                    throw std::invalid_argument("only support svd and pca for now");
-
-                return mode;
-            }()
-        )
-    ) {
+Details::MatrixDecompositionTrainingOnlyPolicy<T>::MatrixDecompositionTrainingOnlyPolicy(DecompositionMethod method, size_t numRows) :
+    //todo:variable validation 
+    _method(method),
+    _numRows(std::move(numRows)) {
 }
 
 template <typename T>
@@ -196,10 +194,33 @@ void Details::MatrixDecompositionTrainingOnlyPolicy<T>::fit(InputType const &inp
 
 template <typename T>
 MatrixDecompositionAnnotationData<T> Details::MatrixDecompositionTrainingOnlyPolicy<T>::complete_training(void) {
-    
-    //do math
 
-    return MatrixDecompositionAnnotationData<T>(_sigma, _u, _v);
+    //svd, pca solver goes here...
+    //svd, pca solver goes here...
+    //svd, pca solver goes here...
+    //svd, pca solver goes here...
+    //svd, pca solver goes here...
+    //svd, pca solver goes here...
+    // ----------------------------------------------------------------------
+    // ----------------------------------------------------------------------
+    // ----------------------------------------------------------------------
+    //sample code. just copy the origin matrix to output variable with the correct shape.
+    size_t numCols = _matrix.size() / _numRows;
+    std::vector<std::double_t> temp_vec;
+    for (T const & val : _matrix) {
+        _sigma.emplace_back(val);
+        temp_vec.emplace_back(val);
+        if (temp_vec.size() % numCols == 0) {
+            _u.emplace_back(temp_vec);
+            _v.emplace_back(temp_vec);
+            temp_vec = {};
+        }   
+    }
+    // ----------------------------------------------------------------------
+    // ----------------------------------------------------------------------
+    // ----------------------------------------------------------------------
+    
+    return MatrixDecompositionAnnotationData<T>(std::move(_sigma), std::move(_u), std::move(_v));
 }
 
 } // namespace Components

--- a/src/Featurizers/Components/MatrixDecompositionEstimator.h
+++ b/src/Featurizers/Components/MatrixDecompositionEstimator.h
@@ -1,0 +1,208 @@
+// ----------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License
+// ----------------------------------------------------------------------
+#pragma once
+
+#include "TrainingOnlyEstimatorImpl.h"
+
+namespace Microsoft {
+namespace Featurizer {
+namespace Featurizers {
+namespace Components {
+
+static constexpr char const * const         MatrixDecompositionEstimatorName("MatrixDecompositionEstimator");
+
+/////////////////////////////////////////////////////////////////////////
+///  \class         MatrixDecompositionAnnotationData
+///  \brief         Contains an MatrixDecomposition 
+///
+template <typename T>
+class MatrixDecompositionAnnotationData {
+public:
+    // ----------------------------------------------------------------------
+    // |
+    // |  Public Types
+    // |
+    // ----------------------------------------------------------------------
+    using SingularValueType                          = T;
+    using SingularVectorType                         = std::vector<SingularValueType>;
+
+    // ----------------------------------------------------------------------
+    // |
+    // |  Public Data
+    // |
+    // ----------------------------------------------------------------------
+    SingularValueType const                          Sigma;
+    SingularVectorType const                         U;
+    SingularVectorType const                         V;
+
+    // ----------------------------------------------------------------------
+    // |
+    // |  Public Methods
+    // |
+    // ----------------------------------------------------------------------
+    MatrixDecompositionAnnotationData(SingularValueType sigma, SingularVectorType u, SingularVectorType v);
+    ~MatrixDecompositionAnnotationData(void) = default;
+
+    FEATURIZER_MOVE_CONSTRUCTOR_ONLY(MatrixDecompositionAnnotationData);
+};
+
+namespace Details {
+
+/////////////////////////////////////////////////////////////////////////
+///  \class         MatrixDecompositionTrainingOnlyPolicy
+///  \brief         `MatrixDecompositionEstimator` implementation details.
+///
+template <typename T>
+class MatrixDecompositionTrainingOnlyPolicy {
+public:
+    // ----------------------------------------------------------------------
+    // |
+    // |  Public Types
+    // |
+    // ----------------------------------------------------------------------
+    using InputType                                  = T;
+    using SingularValueType                          = InputType;
+    using SingularVectorType                         = std::vector<SingularValueType>;
+    using MatrixType                                 = SingularVectorType;
+    // ----------------------------------------------------------------------
+    // |
+    // |  Public Data
+    // |
+    // ----------------------------------------------------------------------
+    static constexpr char const * const     NameValue = MatrixDecompositionEstimatorName;
+
+    // ----------------------------------------------------------------------
+    // |
+    // |  Public Methods
+    // |
+    // ----------------------------------------------------------------------
+    MatrixDecompositionTrainingOnlyPolicy(std::string mode);
+
+    void fit(InputType const &input);
+    MatrixDecompositionAnnotationData<T> complete_training(void);
+
+private:
+    // ----------------------------------------------------------------------
+    // |
+    // |  Private Data
+    // |
+    // ----------------------------------------------------------------------
+    MatrixType                                       _matrix;
+
+    SingularValueType const                          _sigma;
+    SingularVectorType const                         _u;
+    SingularVectorType const                         _v;
+
+    std::string const                                _mode;
+};
+
+} // namespace Details
+
+/////////////////////////////////////////////////////////////////////////
+///  \class         MatrixDecompositionEstimator
+///  \brief         This class 
+///                
+///
+template <
+    typename T,
+    size_t MaxNumTrainingItemsV=std::numeric_limits<size_t>::max()
+>
+class MatrixDecompositionEstimator :
+    public TrainingOnlyEstimatorImpl<
+        Details::MatrixDecompositionTrainingOnlyPolicy<T>,
+        MaxNumTrainingItemsV
+    > {
+public:
+    // ----------------------------------------------------------------------
+    // |
+    // |  Public Types
+    // |
+    // ----------------------------------------------------------------------
+    using BaseType =
+        TrainingOnlyEstimatorImpl<
+            Details::MatrixDecompositionTrainingOnlyPolicy<T>,
+            MaxNumTrainingItemsV
+        >;
+
+    // ----------------------------------------------------------------------
+    // |
+    // |  Public Methods
+    // |
+    // ----------------------------------------------------------------------
+    MatrixDecompositionEstimator(AnnotationMapsPtr pAllColumnAnnotations, size_t colIndex, std::string mode);
+    ~MatrixDecompositionEstimator(void) override = default;
+
+    FEATURIZER_MOVE_CONSTRUCTOR_ONLY(MatrixDecompositionEstimator);
+};
+
+// ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// |
+// |  Implementation
+// |
+// ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+// ----------------------------------------------------------------------
+
+
+// ----------------------------------------------------------------------
+// |
+// |  MatrixDecompositionAnnotationData
+// |
+// ----------------------------------------------------------------------
+template <typename T>
+MatrixDecompositionAnnotationData<T>::MatrixDecompositionAnnotationData(SingularValueType sigma, SingularVectorType u, SingularVectorType v) :
+    Sigma(std::move(sigma)),
+    U(std::move(u)),
+    V(std::move(v)) {
+}
+
+// ----------------------------------------------------------------------
+// |
+// |  MatrixDecompositionEstimator
+// |
+// ----------------------------------------------------------------------
+template <typename T, size_t MaxNumTrainingItemsV>
+MatrixDecompositionEstimator<T, MaxNumTrainingItemsV>::MatrixDecompositionEstimator(AnnotationMapsPtr pAllColumnAnnotations, size_t colIndex, std::string mode) :
+    BaseType(std::move(pAllColumnAnnotations), std::move(colIndex), true, std::move(mode)) {
+}
+
+// ----------------------------------------------------------------------
+// |
+// |  Details::MatrixDecompositionTrainingOnlyPolicy
+// |
+// ----------------------------------------------------------------------
+template <typename T>
+Details::MatrixDecompositionTrainingOnlyPolicy<T>::MatrixDecompositionTrainingOnlyPolicy(std::string mode) :
+    _mode(
+        std::move(
+            [&mode](void) -> std::string & {
+                if(mode != "svd" && mode != "pca")
+                    throw std::invalid_argument("only support svd and pca for now");
+
+                return mode;
+            }()
+        )
+    ) {
+}
+
+template <typename T>
+void Details::MatrixDecompositionTrainingOnlyPolicy<T>::fit(InputType const &input) {
+    _matrix.emplace_back(input);
+}
+
+template <typename T>
+MatrixDecompositionAnnotationData<T> Details::MatrixDecompositionTrainingOnlyPolicy<T>::complete_training(void) {
+    
+    //do math
+
+    return MatrixDecompositionAnnotationData<T>(_sigma, _u, _v);
+}
+
+} // namespace Components
+} // namespace Featurizers
+} // namespace Featurizer
+} // namespace Microsoft

--- a/src/Featurizers/Components/UnitTests/CMakeLists.txt
+++ b/src/Featurizers/Components/UnitTests/CMakeLists.txt
@@ -31,6 +31,7 @@ foreach(_test_name IN ITEMS
     IndexMapEstimator_UnitTest
     InferenceOnlyFeaturizerImpl_UnitTest
     InverseDocumentFrequencyEstimator_UnitTests
+    MatrixDecompositionEstimator_UnitTest
     MaxAbsValueEstimator_UnitTest
     MinMaxEstimator_UnitTest
     ModeEstimator_UnitTest

--- a/src/Featurizers/Components/UnitTests/MatrixDecompositionEstimator_UnitTest.cpp
+++ b/src/Featurizers/Components/UnitTests/MatrixDecompositionEstimator_UnitTest.cpp
@@ -1,0 +1,59 @@
+// ----------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License
+// ----------------------------------------------------------------------
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "../../../3rdParty/optional.h"
+#include "../../TestHelpers.h"
+#include "../IndexMapEstimator.h"
+#include "../HistogramEstimator.h"
+
+namespace NS = Microsoft::Featurizer;
+
+TEST_CASE("CreateIndexMap") {
+    // ----------------------------------------------------------------------
+    using Histogram                         = NS::Featurizers::Components::HistogramAnnotationData<int>::Histogram;
+    using IndexMap                          = NS::Featurizers::Components::IndexMapAnnotationData<int>::IndexMap;
+    // ----------------------------------------------------------------------
+
+    IndexMap const                          result(NS::Featurizers::Components::CreateIndexMap<int>(Histogram{ {5, 1u}, {3, 1u}, {1, 1u}, {2, 1u} }, IndexMap()));
+
+    // Values should be indexed in order
+    CHECK(result == IndexMap{ {1, 0u}, {2, 1u}, {3, 2u}, {5, 3u} });
+
+    // Values appended should appear at the end of the list
+    CHECK(NS::Featurizers::Components::CreateIndexMap<int>(Histogram{ {4, 1u}, {5, 1u}, {3, 1u}, {1, 1u}, {2, 1u} }, result) == IndexMap{ {1, 0u}, {2, 1u}, {3, 2u}, {5, 3u}, {4, 4u} });
+
+    // In-order index when previous values aren't provided
+    CHECK(NS::Featurizers::Components::CreateIndexMap<int>(Histogram{ {4, 1u}, {5, 1u}, {3, 1u}, {1, 1u}, {2, 1u} }, IndexMap()) == IndexMap{ {1, 0u}, {2, 1u}, {3, 2u}, {4, 3u}, {5, 4u}, {4, 4u} });
+}
+
+template <typename T>
+typename NS::Featurizers::Components::IndexMapAnnotationData<T>::IndexMap Test(std::vector<T> const &input) {
+    std::vector<std::vector<T>> const       batchedInput(NS::TestHelpers::make_vector<std::vector<T>>(input));
+    NS::AnnotationMapsPtr                   pAllColumnAnnotations(NS::CreateTestAnnotationMapsPtr(1));
+
+    // Index map requires Histogram annotations
+    NS::Featurizers::Components::IndexMapEstimator<T>   tempIndexMapEstimator(pAllColumnAnnotations, 0);
+
+    CHECK_THROWS_WITH(NS::TestHelpers::Train(tempIndexMapEstimator, batchedInput), "Annotation data was not found for this column");
+
+    // Standard tests
+    NS::Featurizers::Components::HistogramEstimator<T>  histoEstimator(pAllColumnAnnotations, 0);
+    NS::Featurizers::Components::IndexMapEstimator<T>   indexMapEstimator(pAllColumnAnnotations, 0);
+
+    NS::TestHelpers::Train(histoEstimator, batchedInput);
+    NS::TestHelpers::Train(indexMapEstimator, batchedInput);
+
+    return indexMapEstimator.get_annotation_data().Value;
+}
+
+TEST_CASE("Integers") {
+    CHECK(Test<int>({5, 3, 1, 2, 100, 4}) == NS::Featurizers::Components::IndexMapAnnotationData<int>::IndexMap{ {1, 0u}, {2, 1u}, {3, 2u}, {4, 3u}, {5, 4u}, {100, 5u} });
+}
+
+TEST_CASE("Strings") {
+    CHECK(Test<std::string>({"one", "two", "three", "four"}) == NS::Featurizers::Components::IndexMapAnnotationData<std::string>::IndexMap{ {"four", 0u}, {"one", 1u}, {"three", 2u}, {"two", 3u} });
+}

--- a/src/Featurizers/Components/UnitTests/MatrixDecompositionEstimator_UnitTest.cpp
+++ b/src/Featurizers/Components/UnitTests/MatrixDecompositionEstimator_UnitTest.cpp
@@ -7,53 +7,44 @@
 
 #include "../../../3rdParty/optional.h"
 #include "../../TestHelpers.h"
-#include "../IndexMapEstimator.h"
-#include "../HistogramEstimator.h"
+#include "../MatrixDecompositionEstimator.h"
+#include "../../../Traits.h"
 
 namespace NS = Microsoft::Featurizer;
 
-TEST_CASE("CreateIndexMap") {
-    // ----------------------------------------------------------------------
-    using Histogram                         = NS::Featurizers::Components::HistogramAnnotationData<int>::Histogram;
-    using IndexMap                          = NS::Featurizers::Components::IndexMapAnnotationData<int>::IndexMap;
-    // ----------------------------------------------------------------------
+//estimator test
+void Estimator_Test(std::vector<std::vector<std::double_t>> const &inputBatches) {
 
-    IndexMap const                          result(NS::Featurizers::Components::CreateIndexMap<int>(Histogram{ {5, 1u}, {3, 1u}, {1, 1u}, {2, 1u} }, IndexMap()));
+    using MDEstimator                   = NS::Featurizers::Components::MatrixDecompositionEstimator<std::double_t>;
+    using MDAnnotationData              = NS::Featurizers::Components::MatrixDecompositionAnnotationData<std::double_t>;
 
-    // Values should be indexed in order
-    CHECK(result == IndexMap{ {1, 0u}, {2, 1u}, {3, 2u}, {5, 3u} });
+    NS::AnnotationMapsPtr const         pAllColumnAnnotations(NS::CreateTestAnnotationMapsPtr(1));
+    MDEstimator                         estimator(pAllColumnAnnotations, 0, MDEstimator::DecompositionMethod::SVD, 3);
 
-    // Values appended should appear at the end of the list
-    CHECK(NS::Featurizers::Components::CreateIndexMap<int>(Histogram{ {4, 1u}, {5, 1u}, {3, 1u}, {1, 1u}, {2, 1u} }, result) == IndexMap{ {1, 0u}, {2, 1u}, {3, 2u}, {5, 3u}, {4, 4u} });
+    NS::TestHelpers::Train(estimator, inputBatches);
 
-    // In-order index when previous values aren't provided
-    CHECK(NS::Featurizers::Components::CreateIndexMap<int>(Histogram{ {4, 1u}, {5, 1u}, {3, 1u}, {1, 1u}, {2, 1u} }, IndexMap()) == IndexMap{ {1, 0u}, {2, 1u}, {3, 2u}, {4, 3u}, {5, 4u}, {4, 4u} });
+    MDAnnotationData const &            mdAnnotation(estimator.get_annotation_data());
+
+    std::vector<std::vector<std::double_t>> const &                uMat(mdAnnotation.U);
+    std::vector<std::vector<std::double_t>> const &                vMat(mdAnnotation.V);
+    std::vector<std::double_t>              const &                sMat(mdAnnotation.Sigma);
+
+    std::cout << "U: " << NS::Traits<std::vector<std::vector<std::double_t>>>::ToString(uMat) << std::endl;
+    std::cout << "V: " << NS::Traits<std::vector<std::vector<std::double_t>>>::ToString(vMat) << std::endl;
+    std::cout << "S: " << NS::Traits<std::vector<std::double_t>>::ToString(sMat) << std::endl;
 }
 
-template <typename T>
-typename NS::Featurizers::Components::IndexMapAnnotationData<T>::IndexMap Test(std::vector<T> const &input) {
-    std::vector<std::vector<T>> const       batchedInput(NS::TestHelpers::make_vector<std::vector<T>>(input));
-    NS::AnnotationMapsPtr                   pAllColumnAnnotations(NS::CreateTestAnnotationMapsPtr(1));
 
-    // Index map requires Histogram annotations
-    NS::Featurizers::Components::IndexMapEstimator<T>   tempIndexMapEstimator(pAllColumnAnnotations, 0);
-
-    CHECK_THROWS_WITH(NS::TestHelpers::Train(tempIndexMapEstimator, batchedInput), "Annotation data was not found for this column");
-
-    // Standard tests
-    NS::Featurizers::Components::HistogramEstimator<T>  histoEstimator(pAllColumnAnnotations, 0);
-    NS::Featurizers::Components::IndexMapEstimator<T>   indexMapEstimator(pAllColumnAnnotations, 0);
-
-    NS::TestHelpers::Train(histoEstimator, batchedInput);
-    NS::TestHelpers::Train(indexMapEstimator, batchedInput);
-
-    return indexMapEstimator.get_annotation_data().Value;
+//TestWrapper for Estimator test
+void TestWrapper(){
+    auto trainingBatches = 	NS::TestHelpers::make_vector<std::vector<std::double_t>>(
+        NS::TestHelpers::make_vector<std::double_t>(1.0, 2.0, 3.0, 4.0),
+        NS::TestHelpers::make_vector<std::double_t>(5.0, 6.0, 7.0, 8.0),
+        NS::TestHelpers::make_vector<std::double_t>(1.0, 3.0, 7.0, 9.0)
+    );
+    Estimator_Test(trainingBatches);
 }
 
-TEST_CASE("Integers") {
-    CHECK(Test<int>({5, 3, 1, 2, 100, 4}) == NS::Featurizers::Components::IndexMapAnnotationData<int>::IndexMap{ {1, 0u}, {2, 1u}, {3, 2u}, {4, 3u}, {5, 4u}, {100, 5u} });
-}
-
-TEST_CASE("Strings") {
-    CHECK(Test<std::string>({"one", "two", "three", "four"}) == NS::Featurizers::Components::IndexMapAnnotationData<std::string>::IndexMap{ {"four", 0u}, {"one", 1u}, {"three", 2u}, {"two", 3u} });
+TEST_CASE("print") {
+    TestWrapper();
 }


### PR DESCRIPTION
My design is to use this Estimator to solve PCA and SVD(depends on which method to choose) and store the U, V, Sigma in Annotation. Then the PCAfeaturizer and SVDfeaturizer(not yet implemented) can leverage on and may take further actions on the obtained annotation. I foresee these two featurizers are relatively straightforward to implement.

This PR is a temporary one that aiming to check direction correctness. The obvious todo for this estimator is introducing SVDsolver and PCAsolver.  

I recently found Eigen is itself highly dependent, which means I can not easily pick a couple of files as part of library. I am not sure using it as a whole is what we want... 