### PR TITLE
Fixed CatImputer to only take 1 template type instead of 2.

### DIFF
--- a/src/Featurizers/CatImputerFeaturizer.h
+++ b/src/Featurizers/CatImputerFeaturizer.h
@@ -17,6 +17,21 @@ namespace Featurizer {
 namespace Featurizers {
 
 /////////////////////////////////////////////////////////////////////////
+///  \class         CatImputerTraits
+///  \brief         Traits for mapping the input/output types for the CatImptuter.
+///                 This allows us to only change one place if typings need to change.
+///
+
+template <typename TransformedT>
+class CatImputerTraits{
+    using InputType = Traits<TransformedT>::nullable_type;
+    static_assert(Traits<InputType>::IsNullableType, "'InputT' must be a nullable type");
+    static_assert(Traits<TransformedT>::IsNullableType == false || Traits<TransformedT>::IsNativeNullableType, "'TransformedT' must not be a nullable type");
+};
+
+
+
+/////////////////////////////////////////////////////////////////////////
 ///  \class         CatImputerTransformer
 ///  \brief         Transformer that populates null values with the most
 ///                 frequent value found in the training data set.
@@ -29,8 +44,7 @@ public:
     // |  Public Types
     // |
     // ----------------------------------------------------------------------
-    static_assert(Traits<InputT>::IsNullableType, "'InputT' must be a nullable type");
-    static_assert(Traits<TransformedT>::IsNullableType == false || Traits<TransformedT>::IsNativeNullableType, "'TransformedT' must not be a nullable type");
+    
 
     using BaseType                          = StandardTransformer<InputT, TransformedT>;
 

--- a/src/Featurizers/CatImputerFeaturizer.h
+++ b/src/Featurizers/CatImputerFeaturizer.h
@@ -17,11 +17,10 @@ namespace Featurizer {
 namespace Featurizers {
 
 /////////////////////////////////////////////////////////////////////////
-///  \struct         CatImputerTraits
+///  \class        CatImputerTraits
 ///  \brief         Traits for mapping the input/output types for the CatImptuter.
 ///                 This allows us to only change one place if typings need to change.
 ///
-
 template <typename TransformedT>
 struct CatImputerTraits{
     using InputType = typename Traits<TransformedT>::nullable_type;
@@ -59,7 +58,7 @@ public:
     // |  Public Methods
     // |
     // ----------------------------------------------------------------------
-    CatImputerTransformer(typename TransformedType value);
+    CatImputerTransformer(TransformedType value);
     CatImputerTransformer(Archive &ar);
 
     ~CatImputerTransformer(void) override = default;
@@ -74,7 +73,7 @@ private:
     // |  Private Methods
     // |
     // ----------------------------------------------------------------------
-    void execute_impl(typename InputType const &input, typename BaseType::CallbackFunction const &callback) override;
+    void execute_impl(InputType const &input, typename BaseType::CallbackFunction const &callback) override;
 };
 
 namespace Details {
@@ -96,7 +95,7 @@ public:
     // |
     // ----------------------------------------------------------------------
     using InputType                         = typename CatImputerTraits<TransformedT>::InputType;
-    using BaseType                          = TransformerEstimator<typename InputType, TransformedT>;
+    using BaseType                          = TransformerEstimator<InputType, TransformedT>;
     using TransformerType                   = CatImputerTransformer<TransformedT>;
 
     // ----------------------------------------------------------------------
@@ -123,7 +122,7 @@ private:
     // |
     // ----------------------------------------------------------------------
     bool begin_training_impl(void) override;
-    FitResult fit_impl(typename InputType const *, size_t) override;
+    FitResult fit_impl(InputType const *, size_t) override;
     void complete_training_impl(void) override;
 
     // MSVC runs into problems when separating the definition for this method
@@ -198,7 +197,7 @@ public:
 // |
 // ----------------------------------------------------------------------
 template <typename TransformedT>
-CatImputerTransformer<TransformedT>::CatImputerTransformer(typename TransformedType value) :
+CatImputerTransformer<TransformedT>::CatImputerTransformer(TransformedType value) :
     Value(std::move(value)) {
 }
 
@@ -216,7 +215,7 @@ void CatImputerTransformer<TransformedT>::save(Archive &ar) const /*override*/ {
 // ----------------------------------------------------------------------
 // ----------------------------------------------------------------------
 template <typename TransformedT>
-void CatImputerTransformer<TransformedT>::execute_impl(typename InputType const &input, typename BaseType::CallbackFunction const &callback) /*override*/ {
+void CatImputerTransformer<TransformedT>::execute_impl(InputType const &input, typename BaseType::CallbackFunction const &callback) /*override*/ {
     // ----------------------------------------------------------------------
     using TheseTraits                       = Traits<InputType>;
     // ----------------------------------------------------------------------
@@ -272,7 +271,7 @@ bool Details::CatImputerEstimatorImpl<TransformedT, MaxNumTrainingItemsV>::begin
 }
 
 template <typename TransformedT, size_t MaxNumTrainingItemsV>
-FitResult Details::CatImputerEstimatorImpl<TransformedT, MaxNumTrainingItemsV>::fit_impl(typename InputType const *, size_t) /*override*/ {
+FitResult Details::CatImputerEstimatorImpl<TransformedT, MaxNumTrainingItemsV>::fit_impl(InputType const *, size_t) /*override*/ {
     throw std::runtime_error("This should not be called");
 }
 

--- a/src/Featurizers/CatImputerFeaturizer.h
+++ b/src/Featurizers/CatImputerFeaturizer.h
@@ -30,8 +30,6 @@ struct CatImputerTraits{
     static_assert(Traits<TransformedT>::IsNullableType == false || Traits<TransformedT>::IsNativeNullableType, "'TransformedT' must not be a nullable type");
 };
 
-
-
 /////////////////////////////////////////////////////////////////////////
 ///  \class         CatImputerTransformer
 ///  \brief         Transformer that populates null values with the most

--- a/src/Featurizers/UnitTests/CatImputerFeaturizer_UnitTests.cpp
+++ b/src/Featurizers/UnitTests/CatImputerFeaturizer_UnitTests.cpp
@@ -136,9 +136,8 @@ TEST_CASE("CatImputer- All values Null") {
 }
 
 TEST_CASE("Serialization/Deserialization- Numeric") {
-    using type                              = nonstd::optional<std::int64_t>;
     using transformedType                   = std::int64_t;
-    using transformerType                   = NS::Featurizers::CatImputerTransformer<type,transformedType>;
+    using transformerType                   = NS::Featurizers::CatImputerTransformer<transformedType>;
 
     auto model = std::make_shared<transformerType>(10);
 
@@ -153,9 +152,8 @@ TEST_CASE("Serialization/Deserialization- Numeric") {
 }
 
 TEST_CASE("Serialization/Deserialization- string") {
-    using type                              = nonstd::optional<std::string>;
     using transformedType                   = std::string;
-    using transformerType                   = NS::Featurizers::CatImputerTransformer<type,transformedType>;
+    using transformerType                   = NS::Featurizers::CatImputerTransformer<transformedType>;
 
     auto model = std::make_shared<transformerType>("one");
 


### PR DESCRIPTION
Fixed CatImputer to only take 1 template type instead of 2. This change applies to the CatImputerEstimatorImpl and the CatImputerTransformer.