### PR TITLE
Fixes for ORT

### DIFF
--- a/src/Featurizers/CatImputerFeaturizer.h
+++ b/src/Featurizers/CatImputerFeaturizer.h
@@ -22,17 +22,17 @@ namespace Featurizers {
 ///                 frequent value found in the training data set.
 ///
 template <typename TransformedT>
-class CatImputerTransformer : public StandardTransformer<typename MakeNullableType<TransformedT>::InputType, TransformedT> {
+class CatImputerTransformer : public StandardTransformer<typename MakeNullableType<TransformedT>::type, TransformedT> {
 public:
     // ----------------------------------------------------------------------
     // |
     // |  Public Types
     // |
     // ----------------------------------------------------------------------
-
-    using InputType                         = typename MakeNullableType<TransformedT>::InputType;
+    using InputType                         = typename MakeNullableType<TransformedT>::type;
     using BaseType                          = StandardTransformer<InputType, TransformedT>;
     using TransformedType                   = TransformedT;
+
     // ----------------------------------------------------------------------
     // |
     // |  Public Data
@@ -74,14 +74,14 @@ template <
     typename TransformedT,
     size_t MaxNumTrainingItemsV=std::numeric_limits<size_t>::max()
 >
-class CatImputerEstimatorImpl : public TransformerEstimator<typename MakeNullableType<TransformedT>::InputType, TransformedT> {
+class CatImputerEstimatorImpl : public TransformerEstimator<typename MakeNullableType<TransformedT>::type, TransformedT> {
 public:
     // ----------------------------------------------------------------------
     // |
     // |  Public Types
     // |
     // ----------------------------------------------------------------------
-    using InputType                         = typename MakeNullableType<TransformedT>::InputType;
+    using InputType                         = typename MakeNullableType<TransformedT>::type;
     using BaseType                          = TransformerEstimator<InputType, TransformedT>;
     using TransformerType                   = CatImputerTransformer<TransformedT>;
 
@@ -140,8 +140,8 @@ template <
 >
 class CatImputerEstimator :
     public Components::PipelineExecutionEstimatorImpl<
-        Components::HistogramEstimator<typename MakeNullableType<TransformedT>::InputType, MaxNumTrainingItemsV>,
-        Components::ModeEstimator<typename MakeNullableType<TransformedT>::InputType, false, MaxNumTrainingItemsV>,
+        Components::HistogramEstimator<typename MakeNullableType<TransformedT>::type, MaxNumTrainingItemsV>,
+        Components::ModeEstimator<typename MakeNullableType<TransformedT>::type, false, MaxNumTrainingItemsV>,
         Details::CatImputerEstimatorImpl<TransformedT, MaxNumTrainingItemsV>
     > {
 public:
@@ -152,8 +152,8 @@ public:
     // ----------------------------------------------------------------------
     using BaseType =
         Components::PipelineExecutionEstimatorImpl<
-            Components::HistogramEstimator<typename MakeNullableType<TransformedT>::InputType, MaxNumTrainingItemsV>,
-            Components::ModeEstimator<typename MakeNullableType<TransformedT>::InputType, false, MaxNumTrainingItemsV>,
+            Components::HistogramEstimator<typename MakeNullableType<TransformedT>::type, MaxNumTrainingItemsV>,
+            Components::ModeEstimator<typename MakeNullableType<TransformedT>::type, false, MaxNumTrainingItemsV>,
             Details::CatImputerEstimatorImpl<TransformedT, MaxNumTrainingItemsV>
         >;
 
@@ -223,8 +223,8 @@ CatImputerEstimator<TransformedT, MaxNumTrainingItemsV>::CatImputerEstimator(Ann
     BaseType(
         "CatImputerEstimator",
         pAllColumnAnnotations,
-        [pAllColumnAnnotations, colIndex](void) { return Components::HistogramEstimator<typename MakeNullableType<TransformedT>::InputType, MaxNumTrainingItemsV>(std::move(pAllColumnAnnotations), std::move(colIndex)); },
-        [pAllColumnAnnotations, colIndex](void) { return Components::ModeEstimator<typename MakeNullableType<TransformedT>::InputType, false, MaxNumTrainingItemsV>(std::move(pAllColumnAnnotations), std::move(colIndex)); },
+        [pAllColumnAnnotations, colIndex](void) { return Components::HistogramEstimator<typename MakeNullableType<TransformedT>::type, MaxNumTrainingItemsV>(std::move(pAllColumnAnnotations), std::move(colIndex)); },
+        [pAllColumnAnnotations, colIndex](void) { return Components::ModeEstimator<typename MakeNullableType<TransformedT>::type, false, MaxNumTrainingItemsV>(std::move(pAllColumnAnnotations), std::move(colIndex)); },
         [pAllColumnAnnotations, colIndex](void) { return Details::CatImputerEstimatorImpl<TransformedT, MaxNumTrainingItemsV>(std::move(pAllColumnAnnotations), std::move(colIndex)); }
     ) {
 }

--- a/src/Featurizers/CatImputerFeaturizer.h
+++ b/src/Featurizers/CatImputerFeaturizer.h
@@ -17,25 +17,12 @@ namespace Featurizer {
 namespace Featurizers {
 
 /////////////////////////////////////////////////////////////////////////
-///  \class        CatImputerTraits
-///  \brief         Traits for mapping the input/output types for the CatImptuter.
-///                 This allows us to only change one place if typings need to change.
-///
-template <typename TransformedT>
-struct CatImputerTraits{
-    using InputType = typename Traits<TransformedT>::nullable_type;
-
-    static_assert(Traits<InputType>::IsNullableType, "'InputT' must be a nullable type");
-    static_assert(Traits<TransformedT>::IsNullableType == false || Traits<TransformedT>::IsNativeNullableType, "'TransformedT' must not be a nullable type");
-};
-
-/////////////////////////////////////////////////////////////////////////
 ///  \class         CatImputerTransformer
 ///  \brief         Transformer that populates null values with the most
 ///                 frequent value found in the training data set.
 ///
 template <typename TransformedT>
-class CatImputerTransformer : public StandardTransformer<typename CatImputerTraits<TransformedT>::InputType, TransformedT> {
+class CatImputerTransformer : public StandardTransformer<typename MakeNullableType<TransformedT>::InputType, TransformedT> {
 public:
     // ----------------------------------------------------------------------
     // |
@@ -43,7 +30,7 @@ public:
     // |
     // ----------------------------------------------------------------------
 
-    using InputType                         = typename CatImputerTraits<TransformedT>::InputType;
+    using InputType                         = typename MakeNullableType<TransformedT>::InputType;
     using BaseType                          = StandardTransformer<InputType, TransformedT>;
     using TransformedType                   = TransformedT;
     // ----------------------------------------------------------------------
@@ -87,14 +74,14 @@ template <
     typename TransformedT,
     size_t MaxNumTrainingItemsV=std::numeric_limits<size_t>::max()
 >
-class CatImputerEstimatorImpl : public TransformerEstimator<typename CatImputerTraits<TransformedT>::InputType, TransformedT> {
+class CatImputerEstimatorImpl : public TransformerEstimator<typename MakeNullableType<TransformedT>::InputType, TransformedT> {
 public:
     // ----------------------------------------------------------------------
     // |
     // |  Public Types
     // |
     // ----------------------------------------------------------------------
-    using InputType                         = typename CatImputerTraits<TransformedT>::InputType;
+    using InputType                         = typename MakeNullableType<TransformedT>::InputType;
     using BaseType                          = TransformerEstimator<InputType, TransformedT>;
     using TransformerType                   = CatImputerTransformer<TransformedT>;
 
@@ -153,8 +140,8 @@ template <
 >
 class CatImputerEstimator :
     public Components::PipelineExecutionEstimatorImpl<
-        Components::HistogramEstimator<typename CatImputerTraits<TransformedT>::InputType, MaxNumTrainingItemsV>,
-        Components::ModeEstimator<typename CatImputerTraits<TransformedT>::InputType, false, MaxNumTrainingItemsV>,
+        Components::HistogramEstimator<typename MakeNullableType<TransformedT>::InputType, MaxNumTrainingItemsV>,
+        Components::ModeEstimator<typename MakeNullableType<TransformedT>::InputType, false, MaxNumTrainingItemsV>,
         Details::CatImputerEstimatorImpl<TransformedT, MaxNumTrainingItemsV>
     > {
 public:
@@ -165,8 +152,8 @@ public:
     // ----------------------------------------------------------------------
     using BaseType =
         Components::PipelineExecutionEstimatorImpl<
-            Components::HistogramEstimator<typename CatImputerTraits<TransformedT>::InputType, MaxNumTrainingItemsV>,
-            Components::ModeEstimator<typename CatImputerTraits<TransformedT>::InputType, false, MaxNumTrainingItemsV>,
+            Components::HistogramEstimator<typename MakeNullableType<TransformedT>::InputType, MaxNumTrainingItemsV>,
+            Components::ModeEstimator<typename MakeNullableType<TransformedT>::InputType, false, MaxNumTrainingItemsV>,
             Details::CatImputerEstimatorImpl<TransformedT, MaxNumTrainingItemsV>
         >;
 
@@ -236,8 +223,8 @@ CatImputerEstimator<TransformedT, MaxNumTrainingItemsV>::CatImputerEstimator(Ann
     BaseType(
         "CatImputerEstimator",
         pAllColumnAnnotations,
-        [pAllColumnAnnotations, colIndex](void) { return Components::HistogramEstimator<typename CatImputerTraits<TransformedT>::InputType, MaxNumTrainingItemsV>(std::move(pAllColumnAnnotations), std::move(colIndex)); },
-        [pAllColumnAnnotations, colIndex](void) { return Components::ModeEstimator<typename CatImputerTraits<TransformedT>::InputType, false, MaxNumTrainingItemsV>(std::move(pAllColumnAnnotations), std::move(colIndex)); },
+        [pAllColumnAnnotations, colIndex](void) { return Components::HistogramEstimator<typename MakeNullableType<TransformedT>::InputType, MaxNumTrainingItemsV>(std::move(pAllColumnAnnotations), std::move(colIndex)); },
+        [pAllColumnAnnotations, colIndex](void) { return Components::ModeEstimator<typename MakeNullableType<TransformedT>::InputType, false, MaxNumTrainingItemsV>(std::move(pAllColumnAnnotations), std::move(colIndex)); },
         [pAllColumnAnnotations, colIndex](void) { return Details::CatImputerEstimatorImpl<TransformedT, MaxNumTrainingItemsV>(std::move(pAllColumnAnnotations), std::move(colIndex)); }
     ) {
 }

--- a/src/Featurizers/ImputationMarkerFeaturizer.h
+++ b/src/Featurizers/ImputationMarkerFeaturizer.h
@@ -12,30 +12,18 @@ namespace Featurizer {
 namespace Featurizers {
 
 /////////////////////////////////////////////////////////////////////////
-///  \class        ImputationMarkerTraits
-///  \brief         Traits for mapping the input/output types for the ImputationMarker.
-///                 This allows us to only change one place if typings need to change.
-///
-template <typename TransformedT>
-struct ImputationMarkerTraits{
-    using InputType = typename Traits<TransformedT>::nullable_type;
-
-    static_assert(Traits<InputType>::IsNullableType, "'InputT' must be a nullable type");
-};
-
-/////////////////////////////////////////////////////////////////////////
 ///  \class         ImputationMarkerTransformer
 ///  \brief         if input is Null, return true. Otherwise return false
 ///
-template <typename TransformedT>
-class ImputationMarkerTransformer : public Components::InferenceOnlyTransformerImpl<typename ImputationMarkerTraits<TransformedT>::InputType, bool> {
+template <typename T>
+class ImputationMarkerTransformer : public Components::InferenceOnlyTransformerImpl<typename MakeNullableType<T>::InputType, bool> {
 public:
     // ----------------------------------------------------------------------
     // |
     // |  Public Types
     // |
     // ----------------------------------------------------------------------
-    using Type                              = typename ImputationMarkerTraits<TransformedT>::InputType;
+    using Type                              = typename MakeNullableType<T>::InputType;
     using BaseType                          = Components::InferenceOnlyTransformerImpl<Type, bool>;
 
     // ----------------------------------------------------------------------
@@ -94,8 +82,8 @@ public:
 // |  ImputationMarkerEstimator
 // |
 // ----------------------------------------------------------------------
-template <typename TransformedT>
-ImputationMarkerTransformer<TransformedT>::ImputationMarkerTransformer(Archive &ar) :
+template <typename T>
+ImputationMarkerTransformer<T>::ImputationMarkerTransformer(Archive &ar) :
     BaseType(ar) {
 }
 

--- a/src/Featurizers/ImputationMarkerFeaturizer.h
+++ b/src/Featurizers/ImputationMarkerFeaturizer.h
@@ -16,14 +16,14 @@ namespace Featurizers {
 ///  \brief         if input is Null, return true. Otherwise return false
 ///
 template <typename T>
-class ImputationMarkerTransformer : public Components::InferenceOnlyTransformerImpl<typename MakeNullableType<T>::InputType, bool> {
+class ImputationMarkerTransformer : public Components::InferenceOnlyTransformerImpl<typename MakeNullableType<T>::type, bool> {
 public:
     // ----------------------------------------------------------------------
     // |
     // |  Public Types
     // |
     // ----------------------------------------------------------------------
-    using Type                              = typename MakeNullableType<T>::InputType;
+    using Type                              = typename MakeNullableType<T>::type;
     using BaseType                          = Components::InferenceOnlyTransformerImpl<Type, bool>;
 
     // ----------------------------------------------------------------------

--- a/src/Featurizers/MissingDummiesFeaturizer.h
+++ b/src/Featurizers/MissingDummiesFeaturizer.h
@@ -30,7 +30,7 @@ namespace Featurizers {
 ///                 As a result, we would just create another class with a slightly different return
 ///
 template <typename T>
-class MissingDummiesTransformer : public Components::InferenceOnlyTransformerImpl<typename MakeNullableType<T>::InputType, std::int8_t> {
+class MissingDummiesTransformer : public Components::InferenceOnlyTransformerImpl<typename MakeNullableType<T>::type, std::int8_t> {
 public:
     // ----------------------------------------------------------------------
     // |
@@ -38,7 +38,7 @@ public:
     // |
     // ----------------------------------------------------------------------
 
-    using Type                              = typename MakeNullableType<T>::InputType;
+    using Type                              = typename MakeNullableType<T>::type;
     using BaseType                          = Components::InferenceOnlyTransformerImpl<Type, std::int8_t>;
 
     // ----------------------------------------------------------------------

--- a/src/Featurizers/MissingDummiesFeaturizer.h
+++ b/src/Featurizers/MissingDummiesFeaturizer.h
@@ -12,18 +12,6 @@ namespace Featurizer {
 namespace Featurizers {
 
 /////////////////////////////////////////////////////////////////////////
-///  \class        MissingDummiesTraits
-///  \brief         Traits for mapping the input/output types for the MissingDummies.
-///                 This allows us to only change one place if typings need to change.
-///
-template <typename TransformedT>
-struct MissingDummiesTraits{
-    using InputType = typename Traits<TransformedT>::nullable_type;
-
-    static_assert(Traits<InputType>::IsNullableType, "'InputT' must be a nullable type");
-};
-
-/////////////////////////////////////////////////////////////////////////
 ///  \class         MissingDummiesTransformer
 ///  \brief         if input is Null, return 1. Otherwise return 0
 ///
@@ -41,8 +29,8 @@ struct MissingDummiesTraits{
 ///
 ///                 As a result, we would just create another class with a slightly different return
 ///
-template <typename TransformedT>
-class MissingDummiesTransformer : public Components::InferenceOnlyTransformerImpl<typename MissingDummiesTraits<TransformedT>::InputType, std::int8_t> {
+template <typename T>
+class MissingDummiesTransformer : public Components::InferenceOnlyTransformerImpl<typename MakeNullableType<T>::InputType, std::int8_t> {
 public:
     // ----------------------------------------------------------------------
     // |
@@ -50,7 +38,7 @@ public:
     // |
     // ----------------------------------------------------------------------
 
-    using Type                              = typename MissingDummiesTraits<TransformedT>::InputType;
+    using Type                              = typename MakeNullableType<T>::InputType;
     using BaseType                          = Components::InferenceOnlyTransformerImpl<Type, std::int8_t>;
 
     // ----------------------------------------------------------------------
@@ -114,8 +102,8 @@ public:
 // |  MissingDummiesEstimator
 // |
 // ----------------------------------------------------------------------
-template <typename TransformedT>
-MissingDummiesTransformer<TransformedT>::MissingDummiesTransformer(Archive &ar) :
+template <typename T>
+MissingDummiesTransformer<T>::MissingDummiesTransformer(Archive &ar) :
     BaseType(ar) {
 }
 

--- a/src/Featurizers/UnitTests/ImputationMarkerFeaturizer_UnitTests.cpp
+++ b/src/Featurizers/UnitTests/ImputationMarkerFeaturizer_UnitTests.cpp
@@ -32,7 +32,7 @@ TEST_CASE("ImputationMarkerEstimator") {
         .begin_training()
         .complete_training();
 
-    CHECK(dynamic_cast<NS::Featurizers::ImputationMarkerTransformer<nonstd::optional<int>> *>(estimator.create_transformer().get()));
+    CHECK(dynamic_cast<NS::Featurizers::ImputationMarkerTransformer<int> *>(estimator.create_transformer().get()));
 }
 
 TEST_CASE("Single Tests") {

--- a/src/Featurizers/UnitTests/ImputationMarkerFeaturizer_UnitTests.cpp
+++ b/src/Featurizers/UnitTests/ImputationMarkerFeaturizer_UnitTests.cpp
@@ -18,8 +18,8 @@ template <typename T>
 void TestHelper(T const & input) {
     using Type = typename NS::Traits<T>::nullable_type;
     Type nullValue = NS::Traits<T>::CreateNullValue();
-    CHECK(NS::Featurizers::ImputationMarkerTransformer<Type>().execute(input) == false);
-    CHECK(NS::Featurizers::ImputationMarkerTransformer<Type>().execute(nullValue) == true);
+    CHECK(NS::Featurizers::ImputationMarkerTransformer<T>().execute(input) == false);
+    CHECK(NS::Featurizers::ImputationMarkerTransformer<T>().execute(nullValue) == true);
 }
 
 TEST_CASE("ImputationMarkerEstimator") {

--- a/src/Featurizers/UnitTests/MissingDummiesFeaturizer_UnitTests.cpp
+++ b/src/Featurizers/UnitTests/MissingDummiesFeaturizer_UnitTests.cpp
@@ -18,8 +18,8 @@ template <typename T>
 void TestHelper(T const & input) {
     using Type = typename NS::Traits<T>::nullable_type;
     Type nullValue = NS::Traits<T>::CreateNullValue();
-    CHECK(NS::Featurizers::MissingDummiesTransformer<Type>().execute(input) == 0);
-    CHECK(NS::Featurizers::MissingDummiesTransformer<Type>().execute(nullValue) == 1);
+    CHECK(NS::Featurizers::MissingDummiesTransformer<T>().execute(input) == 0);
+    CHECK(NS::Featurizers::MissingDummiesTransformer<T>().execute(nullValue) == 1);
 }
 
 TEST_CASE("MissingDummiesEstimator") {

--- a/src/Featurizers/UnitTests/MissingDummiesFeaturizer_UnitTests.cpp
+++ b/src/Featurizers/UnitTests/MissingDummiesFeaturizer_UnitTests.cpp
@@ -31,7 +31,7 @@ TEST_CASE("MissingDummiesEstimator") {
         .begin_training()
         .complete_training();
 
-    CHECK(dynamic_cast<NS::Featurizers::MissingDummiesTransformer<nonstd::optional<int>> *>(estimator.create_transformer().get()));
+    CHECK(dynamic_cast<NS::Featurizers::MissingDummiesTransformer<int> *>(estimator.create_transformer().get()));
 
 }
 

--- a/src/Tools/CodeGenerator/Plugins/OnnxRuntimePlugin.py
+++ b/src/Tools/CodeGenerator/Plugins/OnnxRuntimePlugin.py
@@ -826,7 +826,7 @@ def _GenerateKernel(
             transformer_name,
         )
 
-    with open(os.path.join(output_dir, "{}.cc".format(transformer_name)), "w") as f:
+    with open(os.path.join(output_dir, "{}.cc".format('_'.join(re.findall('[a-zA-Z][^A-Z]*', transformer_name)).lower())), "w") as f:
         f.write(
             textwrap.dedent(
                 """\

--- a/src/Tools/CodeGenerator/Plugins/OnnxRuntimePlugin.py
+++ b/src/Tools/CodeGenerator/Plugins/OnnxRuntimePlugin.py
@@ -231,7 +231,7 @@ def _GenerateGlobalKernels(
 
         macros += [
             "ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kMSAutoMLDomain, 1, {}, {})".format(
-                input_type.replace("std::", ""),
+                re.sub(r'^std::|_t$', '', input_type),
                 transformer_name,
             )
             for input_type in six.iterkeys(input_type_mappings)
@@ -742,7 +742,7 @@ def _GenerateKernel(
             """\
             inline float_t const & PreprocessOptional(float_t const &value) { return value; }
             inline double_t const & PreprocessOptional(double_t const &value) { return value; }
-            inline nonstd::optional<string> PreprocessOptional(string value) { return value.empty() ? nonstd::optional<string>() : nonstd::optional<string>(std::move(value)); }
+            inline nonstd::optional<std::string> PreprocessOptional(std::string value) { return value.empty() ? nonstd::optional<std::string>() : nonstd::optional<std::string>(std::move(value)); }
             """,
         )
 
@@ -804,8 +804,8 @@ def _GenerateKernel(
                     """,
                 ).format(
                     transformer_name=transformer_name,
-                    input_type_no_namespace = mapping_input_type.replace("std::", ""),
-                    input_type = mapping_input_type if "string" in  mapping_input_type else mapping_input_type.replace("std::", ""),
+                    input_type_no_namespace = re.sub(r'^std::|_t$', '', mapping_input_type),
+                    input_type = mapping_input_type if "string" in  mapping_input_type else re.sub(r'^std::|_t$', '', mapping_input_type),
                     template_input_type=input_type,
                 ) for mapping_input_type in six.iterkeys(input_type_mappings)
             ]
@@ -838,7 +838,7 @@ def _GenerateKernel(
                 #include "core/framework/op_kernel.h"
 
                 #include "Featurizers/{featurizer_name}.h"
-
+                #include "Archive.h"
                 namespace featurizers = Microsoft::Featurizer::Featurizers;
 
                 namespace onnxruntime {{

--- a/src/Traits.h
+++ b/src/Traits.h
@@ -1159,17 +1159,17 @@ struct Traits<nonstd::optional<T>>  {
 // TODO: Apache Arrow
 
 /////////////////////////////////////////////////////////////////////////
-///  \class        MakeNullabeType
+///  \class         MakeNullableType
 ///  \brief         We have many several situations where the transformer operates on nullable types,
 ///                 but we don't want to instantiate the class as Transformer<optional<type>>.
 ///                 This struct allows us to instantiate the class as Transformer<type>, but still be able to
 ///                 operate on optional<type> and to make sure that optional<type> is not initially passed in.
 ///
 template <typename T>
-struct MakeNullableType{
-    using InputType = typename Traits<T>::nullable_type;
-
+struct MakeNullableType {
     static_assert(Traits<T>::IsNullableType == false || Traits<T>::IsNativeNullableType, "'T' must not be a nullable type");
+
+    using type = typename Traits<T>::nullable_type;
 };
 
 } // namespace Featurizer

--- a/src/Traits.h
+++ b/src/Traits.h
@@ -1158,6 +1158,20 @@ struct Traits<nonstd::optional<T>>  {
 // TODO: ONNX (Sparse) Tensor
 // TODO: Apache Arrow
 
+/////////////////////////////////////////////////////////////////////////
+///  \class        MakeNullabeType
+///  \brief         We have many several situations where the transformer operates on nullable types,
+///                 but we don't want to instantiate the class as Transformer<optional<type>>.
+///                 This struct allows us to instantiate the class as Transformer<type>, but still be able to
+///                 operate on optional<type> and to make sure that optional<type> is not initially passed in.
+///
+template <typename T>
+struct MakeNullableType{
+    using InputType = typename Traits<T>::nullable_type;
+
+    static_assert(Traits<T>::IsNullableType == false || Traits<T>::IsNativeNullableType, "'T' must not be a nullable type");
+};
+
 } // namespace Featurizer
 } // namespace Microsoft
 


### PR DESCRIPTION
Fixed Nullable Type issue for ImputationMarkerFeaturizer and MissingDummiesFeaturizer by making transformers take normal types. Same fix as was used with CatImputer
Fixed some ORT code gen issues by removing `_t` and making sure its `std::string`