### PR TITLE
Updates to the featurizer YAML to make types more generic (less specific to C++)

### DIFF
--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_CatImputerFeaturizer.cpp
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_CatImputerFeaturizer.cpp
@@ -24,10 +24,10 @@ extern "C" {
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  CatImputerFeaturizer <int8_t> */
+/* |  CatImputerFeaturizer <int8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateEstimator(/*out*/ CatImputerFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_CreateEstimator(/*out*/ CatImputerFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -40,7 +40,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateEstimator(/*out*/ 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<CatImputerFeaturizer_int8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<CatImputerFeaturizer_int8_EstimatorHandle*>(index);
 
 
     
@@ -52,7 +52,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateEstimator(/*out*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_DestroyEstimator(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -75,7 +75,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_DestroyEstimator(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_GetState(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_GetState(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -97,7 +97,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_GetState(/*in*/ CatImput
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -119,7 +119,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_IsTrainingComplete(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_Fit(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_Fit(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -145,7 +145,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_Fit(/*in*/ CatImputerFea
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_FitBuffer(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_FitBuffer(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -187,7 +187,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_FitBuffer(/*in*/ CatImpu
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_OnDataCompleted(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -208,7 +208,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_OnDataCompleted(/*in*/ C
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CompleteTraining(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_CompleteTraining(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -229,7 +229,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CompleteTraining(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -247,7 +247,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateTransformerFromEst
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -257,7 +257,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateTransformerFromEst
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -273,7 +273,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateTransformerFromSav
         Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::int8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::int8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -283,7 +283,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateTransformerFromSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_DestroyTransformer(/*in*/ CatImputerFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -307,7 +307,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_DestroyTransformer(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -340,7 +340,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateTransformerSaveDat
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_Transform(/*in*/ CatImputerFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_Transform(/*in*/ CatImputerFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -371,10 +371,10 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_Transform(/*in*/ CatImpu
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  CatImputerFeaturizer <int16_t> */
+/* |  CatImputerFeaturizer <int16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateEstimator(/*out*/ CatImputerFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_CreateEstimator(/*out*/ CatImputerFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -387,7 +387,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateEstimator(/*out*/
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<CatImputerFeaturizer_int16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<CatImputerFeaturizer_int16_EstimatorHandle*>(index);
 
 
     
@@ -399,7 +399,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateEstimator(/*out*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_DestroyEstimator(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -422,7 +422,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_DestroyEstimator(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_GetState(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_GetState(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -444,7 +444,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_GetState(/*in*/ CatImpu
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -466,7 +466,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_IsTrainingComplete(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_Fit(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_Fit(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -492,7 +492,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_Fit(/*in*/ CatImputerFe
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_FitBuffer(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_FitBuffer(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -534,7 +534,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_FitBuffer(/*in*/ CatImp
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_OnDataCompleted(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -555,7 +555,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_OnDataCompleted(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CompleteTraining(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_CompleteTraining(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -576,7 +576,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CompleteTraining(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -594,7 +594,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateTransformerFromEs
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -604,7 +604,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateTransformerFromEs
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -620,7 +620,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateTransformerFromSa
         Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::int16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::int16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -630,7 +630,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateTransformerFromSa
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_DestroyTransformer(/*in*/ CatImputerFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -654,7 +654,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_DestroyTransformer(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -687,7 +687,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateTransformerSaveDa
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_Transform(/*in*/ CatImputerFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t const * input, /*out*/ int16_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_Transform(/*in*/ CatImputerFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t const * input, /*out*/ int16_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -718,10 +718,10 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_Transform(/*in*/ CatImp
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  CatImputerFeaturizer <int32_t> */
+/* |  CatImputerFeaturizer <int32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateEstimator(/*out*/ CatImputerFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_CreateEstimator(/*out*/ CatImputerFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -734,7 +734,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateEstimator(/*out*/
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<CatImputerFeaturizer_int32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<CatImputerFeaturizer_int32_EstimatorHandle*>(index);
 
 
     
@@ -746,7 +746,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateEstimator(/*out*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_DestroyEstimator(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -769,7 +769,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_DestroyEstimator(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_GetState(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_GetState(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -791,7 +791,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_GetState(/*in*/ CatImpu
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -813,7 +813,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_IsTrainingComplete(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_Fit(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_Fit(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -839,7 +839,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_Fit(/*in*/ CatImputerFe
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_FitBuffer(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_FitBuffer(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -881,7 +881,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_FitBuffer(/*in*/ CatImp
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_OnDataCompleted(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -902,7 +902,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_OnDataCompleted(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CompleteTraining(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_CompleteTraining(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -923,7 +923,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CompleteTraining(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -941,7 +941,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateTransformerFromEs
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -951,7 +951,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateTransformerFromEs
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -967,7 +967,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateTransformerFromSa
         Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::int32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::int32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -977,7 +977,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateTransformerFromSa
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_DestroyTransformer(/*in*/ CatImputerFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1001,7 +1001,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_DestroyTransformer(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1034,7 +1034,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateTransformerSaveDa
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_Transform(/*in*/ CatImputerFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t const * input, /*out*/ int32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_Transform(/*in*/ CatImputerFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t const * input, /*out*/ int32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1065,10 +1065,10 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_Transform(/*in*/ CatImp
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  CatImputerFeaturizer <int64_t> */
+/* |  CatImputerFeaturizer <int64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateEstimator(/*out*/ CatImputerFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_CreateEstimator(/*out*/ CatImputerFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1081,7 +1081,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateEstimator(/*out*/
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<CatImputerFeaturizer_int64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<CatImputerFeaturizer_int64_EstimatorHandle*>(index);
 
 
     
@@ -1093,7 +1093,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateEstimator(/*out*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_DestroyEstimator(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1116,7 +1116,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_DestroyEstimator(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_GetState(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_GetState(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1138,7 +1138,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_GetState(/*in*/ CatImpu
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1160,7 +1160,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_IsTrainingComplete(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_Fit(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_Fit(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1186,7 +1186,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_Fit(/*in*/ CatImputerFe
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_FitBuffer(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_FitBuffer(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1228,7 +1228,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_FitBuffer(/*in*/ CatImp
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_OnDataCompleted(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1249,7 +1249,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_OnDataCompleted(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CompleteTraining(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_CompleteTraining(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1270,7 +1270,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CompleteTraining(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1288,7 +1288,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateTransformerFromEs
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1298,7 +1298,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateTransformerFromEs
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1314,7 +1314,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateTransformerFromSa
         Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::int64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::int64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1324,7 +1324,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateTransformerFromSa
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_DestroyTransformer(/*in*/ CatImputerFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1348,7 +1348,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_DestroyTransformer(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1381,7 +1381,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateTransformerSaveDa
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_Transform(/*in*/ CatImputerFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t const * input, /*out*/ int64_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_Transform(/*in*/ CatImputerFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t const * input, /*out*/ int64_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1412,10 +1412,10 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_Transform(/*in*/ CatImp
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  CatImputerFeaturizer <uint8_t> */
+/* |  CatImputerFeaturizer <uint8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateEstimator(/*out*/ CatImputerFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_CreateEstimator(/*out*/ CatImputerFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1428,7 +1428,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateEstimator(/*out*/
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<CatImputerFeaturizer_uint8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<CatImputerFeaturizer_uint8_EstimatorHandle*>(index);
 
 
     
@@ -1440,7 +1440,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateEstimator(/*out*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1463,7 +1463,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_DestroyEstimator(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_GetState(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_GetState(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1485,7 +1485,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_GetState(/*in*/ CatImpu
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1507,7 +1507,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_IsTrainingComplete(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_Fit(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_Fit(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1533,7 +1533,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_Fit(/*in*/ CatImputerFe
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_FitBuffer(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_FitBuffer(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1575,7 +1575,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_FitBuffer(/*in*/ CatImp
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1596,7 +1596,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_OnDataCompleted(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CompleteTraining(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_CompleteTraining(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1617,7 +1617,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CompleteTraining(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1635,7 +1635,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateTransformerFromEs
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1645,7 +1645,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateTransformerFromEs
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1661,7 +1661,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateTransformerFromSa
         Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::uint8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::uint8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1671,7 +1671,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateTransformerFromSa
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1695,7 +1695,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_DestroyTransformer(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1728,7 +1728,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateTransformerSaveDa
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_Transform(/*in*/ CatImputerFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ uint8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_Transform(/*in*/ CatImputerFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ uint8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1759,10 +1759,10 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_Transform(/*in*/ CatImp
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  CatImputerFeaturizer <uint16_t> */
+/* |  CatImputerFeaturizer <uint16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateEstimator(/*out*/ CatImputerFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_CreateEstimator(/*out*/ CatImputerFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1775,7 +1775,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateEstimator(/*out*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<CatImputerFeaturizer_uint16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<CatImputerFeaturizer_uint16_EstimatorHandle*>(index);
 
 
     
@@ -1787,7 +1787,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateEstimator(/*out*
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1810,7 +1810,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_DestroyEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_GetState(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_GetState(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1832,7 +1832,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_GetState(/*in*/ CatImp
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1854,7 +1854,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_IsTrainingComplete(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_Fit(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_Fit(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1880,7 +1880,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_Fit(/*in*/ CatImputerF
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_FitBuffer(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_FitBuffer(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1922,7 +1922,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_FitBuffer(/*in*/ CatIm
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1943,7 +1943,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_OnDataCompleted(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CompleteTraining(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_CompleteTraining(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1964,7 +1964,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CompleteTraining(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1982,7 +1982,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateTransformerFromE
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -1992,7 +1992,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateTransformerFromE
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2008,7 +2008,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateTransformerFromS
         Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::uint16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::uint16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -2018,7 +2018,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateTransformerFromS
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2042,7 +2042,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_DestroyTransformer(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2075,7 +2075,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateTransformerSaveD
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_Transform(/*in*/ CatImputerFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ uint16_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_Transform(/*in*/ CatImputerFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ uint16_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2106,10 +2106,10 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_Transform(/*in*/ CatIm
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  CatImputerFeaturizer <uint32_t> */
+/* |  CatImputerFeaturizer <uint32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateEstimator(/*out*/ CatImputerFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_CreateEstimator(/*out*/ CatImputerFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2122,7 +2122,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateEstimator(/*out*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<CatImputerFeaturizer_uint32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<CatImputerFeaturizer_uint32_EstimatorHandle*>(index);
 
 
     
@@ -2134,7 +2134,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateEstimator(/*out*
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2157,7 +2157,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_DestroyEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_GetState(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_GetState(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2179,7 +2179,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_GetState(/*in*/ CatImp
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2201,7 +2201,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_IsTrainingComplete(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_Fit(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_Fit(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2227,7 +2227,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_Fit(/*in*/ CatImputerF
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_FitBuffer(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_FitBuffer(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2269,7 +2269,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_FitBuffer(/*in*/ CatIm
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2290,7 +2290,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_OnDataCompleted(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CompleteTraining(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_CompleteTraining(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2311,7 +2311,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CompleteTraining(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2329,7 +2329,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateTransformerFromE
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2339,7 +2339,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateTransformerFromE
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2355,7 +2355,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateTransformerFromS
         Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::uint32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::uint32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2365,7 +2365,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateTransformerFromS
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2389,7 +2389,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_DestroyTransformer(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2422,7 +2422,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateTransformerSaveD
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_Transform(/*in*/ CatImputerFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_Transform(/*in*/ CatImputerFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2453,10 +2453,10 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_Transform(/*in*/ CatIm
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  CatImputerFeaturizer <uint64_t> */
+/* |  CatImputerFeaturizer <uint64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateEstimator(/*out*/ CatImputerFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_CreateEstimator(/*out*/ CatImputerFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2469,7 +2469,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateEstimator(/*out*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<CatImputerFeaturizer_uint64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<CatImputerFeaturizer_uint64_EstimatorHandle*>(index);
 
 
     
@@ -2481,7 +2481,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateEstimator(/*out*
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2504,7 +2504,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_DestroyEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_GetState(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_GetState(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2526,7 +2526,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_GetState(/*in*/ CatImp
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2548,7 +2548,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_IsTrainingComplete(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_Fit(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_Fit(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2574,7 +2574,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_Fit(/*in*/ CatImputerF
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_FitBuffer(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_FitBuffer(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2616,7 +2616,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_FitBuffer(/*in*/ CatIm
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2637,7 +2637,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_OnDataCompleted(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CompleteTraining(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_CompleteTraining(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2658,7 +2658,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CompleteTraining(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2676,7 +2676,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateTransformerFromE
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2686,7 +2686,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateTransformerFromE
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2702,7 +2702,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateTransformerFromS
         Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::uint64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::uint64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2712,7 +2712,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateTransformerFromS
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2736,7 +2736,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_DestroyTransformer(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2769,7 +2769,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateTransformerSaveD
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_Transform(/*in*/ CatImputerFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ uint64_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_Transform(/*in*/ CatImputerFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ uint64_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2800,10 +2800,10 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_Transform(/*in*/ CatIm
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  CatImputerFeaturizer <float_t> */
+/* |  CatImputerFeaturizer <float> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateEstimator(/*out*/ CatImputerFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_CreateEstimator(/*out*/ CatImputerFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2816,7 +2816,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateEstimator(/*out*/
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<CatImputerFeaturizer_float_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<CatImputerFeaturizer_float_EstimatorHandle*>(index);
 
 
     
@@ -2828,7 +2828,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateEstimator(/*out*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_DestroyEstimator(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2851,7 +2851,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_DestroyEstimator(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_GetState(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_GetState(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2873,7 +2873,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_GetState(/*in*/ CatImpu
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_IsTrainingComplete(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2895,7 +2895,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_IsTrainingComplete(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_Fit(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_Fit(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2921,7 +2921,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_Fit(/*in*/ CatImputerFe
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_FitBuffer(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_FitBuffer(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2963,7 +2963,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_FitBuffer(/*in*/ CatImp
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_OnDataCompleted(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2984,7 +2984,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_OnDataCompleted(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CompleteTraining(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_CompleteTraining(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3005,7 +3005,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CompleteTraining(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3023,7 +3023,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateTransformerFromEs
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -3033,7 +3033,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateTransformerFromEs
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3049,7 +3049,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateTransformerFromSa
         Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::float_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -3059,7 +3059,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateTransformerFromSa
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_DestroyTransformer(/*in*/ CatImputerFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3083,7 +3083,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_DestroyTransformer(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3116,7 +3116,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateTransformerSaveDa
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_Transform(/*in*/ CatImputerFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float const * input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_Transform(/*in*/ CatImputerFeaturizer_float_TransformerHandle *pHandle, /*in*/ float const * input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3147,10 +3147,10 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_Transform(/*in*/ CatImp
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  CatImputerFeaturizer <double_t> */
+/* |  CatImputerFeaturizer <double> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateEstimator(/*out*/ CatImputerFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_CreateEstimator(/*out*/ CatImputerFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3163,7 +3163,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateEstimator(/*out*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<CatImputerFeaturizer_double_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<CatImputerFeaturizer_double_EstimatorHandle*>(index);
 
 
     
@@ -3175,7 +3175,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateEstimator(/*out*
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_DestroyEstimator(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3198,7 +3198,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_DestroyEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_GetState(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_GetState(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3220,7 +3220,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_GetState(/*in*/ CatImp
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_IsTrainingComplete(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3242,7 +3242,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_IsTrainingComplete(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_Fit(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_Fit(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3268,7 +3268,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_Fit(/*in*/ CatImputerF
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_FitBuffer(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_FitBuffer(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3310,7 +3310,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_FitBuffer(/*in*/ CatIm
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_OnDataCompleted(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3331,7 +3331,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_OnDataCompleted(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CompleteTraining(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_CompleteTraining(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3352,7 +3352,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CompleteTraining(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3370,7 +3370,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateTransformerFromE
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3380,7 +3380,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateTransformerFromE
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3396,7 +3396,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateTransformerFromS
         Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::CatImputerEstimator<std::double_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<CatImputerFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3406,7 +3406,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateTransformerFromS
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_DestroyTransformer(/*in*/ CatImputerFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3430,7 +3430,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_DestroyTransformer(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3463,7 +3463,7 @@ FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateTransformerSaveD
     }
 }
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_Transform(/*in*/ CatImputerFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double const * input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_Transform(/*in*/ CatImputerFeaturizer_double_TransformerHandle *pHandle, /*in*/ double const * input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_CatImputerFeaturizer.h
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_CatImputerFeaturizer.h
@@ -9,254 +9,254 @@
 extern "C" {
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <int8_t> */
-struct CatImputerFeaturizer_int8_t_EstimatorHandle {};
-struct CatImputerFeaturizer_int8_t_TransformerHandle {};
+/* |  CatImputerFeaturizer <int8> */
+struct CatImputerFeaturizer_int8_EstimatorHandle {};
+struct CatImputerFeaturizer_int8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateEstimator(/*out*/ CatImputerFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_CreateEstimator(/*out*/ CatImputerFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_DestroyEstimator(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_GetState(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_Fit(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_FitBuffer(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CompleteTraining(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_GetState(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_Fit(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_FitBuffer(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_OnDataCompleted(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_CompleteTraining(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_DestroyTransformer(/*in*/ CatImputerFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_t_Transform(/*in*/ CatImputerFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int8_Transform(/*in*/ CatImputerFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <int16_t> */
-struct CatImputerFeaturizer_int16_t_EstimatorHandle {};
-struct CatImputerFeaturizer_int16_t_TransformerHandle {};
+/* |  CatImputerFeaturizer <int16> */
+struct CatImputerFeaturizer_int16_EstimatorHandle {};
+struct CatImputerFeaturizer_int16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateEstimator(/*out*/ CatImputerFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_CreateEstimator(/*out*/ CatImputerFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_DestroyEstimator(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_GetState(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_Fit(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_FitBuffer(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CompleteTraining(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_GetState(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_Fit(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_FitBuffer(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_OnDataCompleted(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_CompleteTraining(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_DestroyTransformer(/*in*/ CatImputerFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_t_Transform(/*in*/ CatImputerFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t const * input, /*out*/ int16_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int16_Transform(/*in*/ CatImputerFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t const * input, /*out*/ int16_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <int32_t> */
-struct CatImputerFeaturizer_int32_t_EstimatorHandle {};
-struct CatImputerFeaturizer_int32_t_TransformerHandle {};
+/* |  CatImputerFeaturizer <int32> */
+struct CatImputerFeaturizer_int32_EstimatorHandle {};
+struct CatImputerFeaturizer_int32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateEstimator(/*out*/ CatImputerFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_CreateEstimator(/*out*/ CatImputerFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_DestroyEstimator(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_GetState(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_Fit(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_FitBuffer(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CompleteTraining(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_GetState(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_Fit(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_FitBuffer(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_OnDataCompleted(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_CompleteTraining(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_DestroyTransformer(/*in*/ CatImputerFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_t_Transform(/*in*/ CatImputerFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t const * input, /*out*/ int32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int32_Transform(/*in*/ CatImputerFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t const * input, /*out*/ int32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <int64_t> */
-struct CatImputerFeaturizer_int64_t_EstimatorHandle {};
-struct CatImputerFeaturizer_int64_t_TransformerHandle {};
+/* |  CatImputerFeaturizer <int64> */
+struct CatImputerFeaturizer_int64_EstimatorHandle {};
+struct CatImputerFeaturizer_int64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateEstimator(/*out*/ CatImputerFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_CreateEstimator(/*out*/ CatImputerFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_DestroyEstimator(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_GetState(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_Fit(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_FitBuffer(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CompleteTraining(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_GetState(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_IsTrainingComplete(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_Fit(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_FitBuffer(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_OnDataCompleted(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_CompleteTraining(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_DestroyTransformer(/*in*/ CatImputerFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_t_Transform(/*in*/ CatImputerFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t const * input, /*out*/ int64_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_int64_Transform(/*in*/ CatImputerFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t const * input, /*out*/ int64_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <uint8_t> */
-struct CatImputerFeaturizer_uint8_t_EstimatorHandle {};
-struct CatImputerFeaturizer_uint8_t_TransformerHandle {};
+/* |  CatImputerFeaturizer <uint8> */
+struct CatImputerFeaturizer_uint8_EstimatorHandle {};
+struct CatImputerFeaturizer_uint8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateEstimator(/*out*/ CatImputerFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_CreateEstimator(/*out*/ CatImputerFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_GetState(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_Fit(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_FitBuffer(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CompleteTraining(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_GetState(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_Fit(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_FitBuffer(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_CompleteTraining(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_t_Transform(/*in*/ CatImputerFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ uint8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint8_Transform(/*in*/ CatImputerFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ uint8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <uint16_t> */
-struct CatImputerFeaturizer_uint16_t_EstimatorHandle {};
-struct CatImputerFeaturizer_uint16_t_TransformerHandle {};
+/* |  CatImputerFeaturizer <uint16> */
+struct CatImputerFeaturizer_uint16_EstimatorHandle {};
+struct CatImputerFeaturizer_uint16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateEstimator(/*out*/ CatImputerFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_CreateEstimator(/*out*/ CatImputerFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_GetState(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_Fit(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_FitBuffer(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CompleteTraining(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_GetState(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_Fit(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_FitBuffer(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_CompleteTraining(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_t_Transform(/*in*/ CatImputerFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ uint16_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint16_Transform(/*in*/ CatImputerFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ uint16_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <uint32_t> */
-struct CatImputerFeaturizer_uint32_t_EstimatorHandle {};
-struct CatImputerFeaturizer_uint32_t_TransformerHandle {};
+/* |  CatImputerFeaturizer <uint32> */
+struct CatImputerFeaturizer_uint32_EstimatorHandle {};
+struct CatImputerFeaturizer_uint32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateEstimator(/*out*/ CatImputerFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_CreateEstimator(/*out*/ CatImputerFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_GetState(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_Fit(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_FitBuffer(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CompleteTraining(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_GetState(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_Fit(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_FitBuffer(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_CompleteTraining(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_t_Transform(/*in*/ CatImputerFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint32_Transform(/*in*/ CatImputerFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <uint64_t> */
-struct CatImputerFeaturizer_uint64_t_EstimatorHandle {};
-struct CatImputerFeaturizer_uint64_t_TransformerHandle {};
+/* |  CatImputerFeaturizer <uint64> */
+struct CatImputerFeaturizer_uint64_EstimatorHandle {};
+struct CatImputerFeaturizer_uint64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateEstimator(/*out*/ CatImputerFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_CreateEstimator(/*out*/ CatImputerFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_DestroyEstimator(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_GetState(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_Fit(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_FitBuffer(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CompleteTraining(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_GetState(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_IsTrainingComplete(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_Fit(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_FitBuffer(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_OnDataCompleted(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_CompleteTraining(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_DestroyTransformer(/*in*/ CatImputerFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_t_Transform(/*in*/ CatImputerFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ uint64_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_uint64_Transform(/*in*/ CatImputerFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ uint64_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <float_t> */
-struct CatImputerFeaturizer_float_t_EstimatorHandle {};
-struct CatImputerFeaturizer_float_t_TransformerHandle {};
+/* |  CatImputerFeaturizer <float> */
+struct CatImputerFeaturizer_float_EstimatorHandle {};
+struct CatImputerFeaturizer_float_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateEstimator(/*out*/ CatImputerFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_CreateEstimator(/*out*/ CatImputerFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_DestroyEstimator(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_GetState(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_Fit(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_FitBuffer(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CompleteTraining(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_GetState(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_IsTrainingComplete(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_Fit(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_FitBuffer(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_OnDataCompleted(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_CompleteTraining(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_DestroyTransformer(/*in*/ CatImputerFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_t_Transform(/*in*/ CatImputerFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float const * input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_float_Transform(/*in*/ CatImputerFeaturizer_float_TransformerHandle *pHandle, /*in*/ float const * input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <double_t> */
-struct CatImputerFeaturizer_double_t_EstimatorHandle {};
-struct CatImputerFeaturizer_double_t_TransformerHandle {};
+/* |  CatImputerFeaturizer <double> */
+struct CatImputerFeaturizer_double_EstimatorHandle {};
+struct CatImputerFeaturizer_double_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateEstimator(/*out*/ CatImputerFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_DestroyEstimator(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_CreateEstimator(/*out*/ CatImputerFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_DestroyEstimator(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_GetState(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_IsTrainingComplete(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_Fit(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_FitBuffer(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_OnDataCompleted(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CompleteTraining(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_GetState(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_IsTrainingComplete(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_Fit(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_FitBuffer(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_OnDataCompleted(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_CompleteTraining(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_DestroyTransformer(/*in*/ CatImputerFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_CreateTransformerFromEstimator(/*in*/ CatImputerFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ CatImputerFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ CatImputerFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_DestroyTransformer(/*in*/ CatImputerFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_CreateTransformerSaveData(/*in*/ CatImputerFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_t_Transform(/*in*/ CatImputerFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double const * input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool CatImputerFeaturizer_double_Transform(/*in*/ CatImputerFeaturizer_double_TransformerHandle *pHandle, /*in*/ double const * input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
 /* |  CatImputerFeaturizer <bool> */

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_HashOneHotVectorizerFeaturizer.cpp
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_HashOneHotVectorizerFeaturizer.cpp
@@ -24,10 +24,10 @@ extern "C" {
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  HashOneHotVectorizerFeaturizer <int8_t> */
+/* |  HashOneHotVectorizerFeaturizer <int8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -40,7 +40,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateEstimato
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int8_EstimatorHandle*>(index);
 
 
     
@@ -52,7 +52,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateEstimato
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -75,7 +75,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_DestroyEstimat
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -97,7 +97,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_GetState(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -119,7 +119,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_IsTrainingComp
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -145,7 +145,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_Fit(/*in*/ Has
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -172,7 +172,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_FitBuffer(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -193,7 +193,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_OnDataComplete
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -214,7 +214,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CompleteTraini
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -232,7 +232,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateTransfor
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -242,7 +242,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateTransfor
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -258,7 +258,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateTransfor
         Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::int8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::int8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -268,7 +268,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateTransfor
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -292,7 +292,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_DestroyTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -325,7 +325,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateTransfor
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -356,7 +356,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_Transform(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -377,10 +377,10 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_DestroyTransfo
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  HashOneHotVectorizerFeaturizer <int16_t> */
+/* |  HashOneHotVectorizerFeaturizer <int16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -393,7 +393,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateEstimat
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int16_EstimatorHandle*>(index);
 
 
     
@@ -405,7 +405,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateEstimat
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -428,7 +428,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_DestroyEstima
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -450,7 +450,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_GetState(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -472,7 +472,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_IsTrainingCom
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -498,7 +498,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_Fit(/*in*/ Ha
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -525,7 +525,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_FitBuffer(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -546,7 +546,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_OnDataComplet
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -567,7 +567,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CompleteTrain
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -585,7 +585,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateTransfo
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -595,7 +595,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -611,7 +611,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateTransfo
         Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::int16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::int16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -621,7 +621,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -645,7 +645,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_DestroyTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -678,7 +678,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -709,7 +709,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_Transform(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -730,10 +730,10 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_DestroyTransf
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  HashOneHotVectorizerFeaturizer <int32_t> */
+/* |  HashOneHotVectorizerFeaturizer <int32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -746,7 +746,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateEstimat
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int32_EstimatorHandle*>(index);
 
 
     
@@ -758,7 +758,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateEstimat
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -781,7 +781,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_DestroyEstima
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -803,7 +803,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_GetState(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -825,7 +825,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_IsTrainingCom
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -851,7 +851,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_Fit(/*in*/ Ha
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -878,7 +878,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_FitBuffer(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -899,7 +899,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_OnDataComplet
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -920,7 +920,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CompleteTrain
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -938,7 +938,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateTransfo
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -948,7 +948,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -964,7 +964,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateTransfo
         Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::int32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::int32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -974,7 +974,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -998,7 +998,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_DestroyTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1031,7 +1031,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1062,7 +1062,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_Transform(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1083,10 +1083,10 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_DestroyTransf
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  HashOneHotVectorizerFeaturizer <int64_t> */
+/* |  HashOneHotVectorizerFeaturizer <int64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1099,7 +1099,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateEstimat
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int64_EstimatorHandle*>(index);
 
 
     
@@ -1111,7 +1111,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateEstimat
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1134,7 +1134,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_DestroyEstima
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1156,7 +1156,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_GetState(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1178,7 +1178,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_IsTrainingCom
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1204,7 +1204,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_Fit(/*in*/ Ha
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1231,7 +1231,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_FitBuffer(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1252,7 +1252,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_OnDataComplet
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1273,7 +1273,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CompleteTrain
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1291,7 +1291,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateTransfo
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1301,7 +1301,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1317,7 +1317,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateTransfo
         Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::int64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::int64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1327,7 +1327,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1351,7 +1351,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_DestroyTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1384,7 +1384,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1415,7 +1415,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_Transform(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1436,10 +1436,10 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_DestroyTransf
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  HashOneHotVectorizerFeaturizer <uint8_t> */
+/* |  HashOneHotVectorizerFeaturizer <uint8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1452,7 +1452,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateEstimat
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle*>(index);
 
 
     
@@ -1464,7 +1464,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateEstimat
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1487,7 +1487,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_DestroyEstima
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1509,7 +1509,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_GetState(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1531,7 +1531,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_IsTrainingCom
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1557,7 +1557,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_Fit(/*in*/ Ha
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1584,7 +1584,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_FitBuffer(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1605,7 +1605,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_OnDataComplet
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1626,7 +1626,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CompleteTrain
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1644,7 +1644,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateTransfo
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1654,7 +1654,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1670,7 +1670,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateTransfo
         Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::uint8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::uint8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1680,7 +1680,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1704,7 +1704,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_DestroyTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1737,7 +1737,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1768,7 +1768,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_Transform(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1789,10 +1789,10 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_DestroyTransf
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  HashOneHotVectorizerFeaturizer <uint16_t> */
+/* |  HashOneHotVectorizerFeaturizer <uint16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1805,7 +1805,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateEstima
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle*>(index);
 
 
     
@@ -1817,7 +1817,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateEstima
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1840,7 +1840,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_DestroyEstim
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1862,7 +1862,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_GetState(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1884,7 +1884,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_IsTrainingCo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1910,7 +1910,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_Fit(/*in*/ H
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1937,7 +1937,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_FitBuffer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1958,7 +1958,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_OnDataComple
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1979,7 +1979,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CompleteTrai
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1997,7 +1997,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateTransf
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -2007,7 +2007,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2023,7 +2023,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateTransf
         Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::uint16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::uint16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -2033,7 +2033,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2057,7 +2057,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_DestroyTrans
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2090,7 +2090,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2121,7 +2121,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_Transform(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2142,10 +2142,10 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_DestroyTrans
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  HashOneHotVectorizerFeaturizer <uint32_t> */
+/* |  HashOneHotVectorizerFeaturizer <uint32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2158,7 +2158,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateEstima
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle*>(index);
 
 
     
@@ -2170,7 +2170,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateEstima
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2193,7 +2193,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_DestroyEstim
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2215,7 +2215,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_GetState(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2237,7 +2237,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_IsTrainingCo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2263,7 +2263,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_Fit(/*in*/ H
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2290,7 +2290,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_FitBuffer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2311,7 +2311,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_OnDataComple
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2332,7 +2332,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CompleteTrai
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2350,7 +2350,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateTransf
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2360,7 +2360,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2376,7 +2376,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateTransf
         Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::uint32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::uint32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2386,7 +2386,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2410,7 +2410,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_DestroyTrans
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2443,7 +2443,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2474,7 +2474,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_Transform(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2495,10 +2495,10 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_DestroyTrans
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  HashOneHotVectorizerFeaturizer <uint64_t> */
+/* |  HashOneHotVectorizerFeaturizer <uint64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2511,7 +2511,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateEstima
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle*>(index);
 
 
     
@@ -2523,7 +2523,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateEstima
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2546,7 +2546,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_DestroyEstim
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2568,7 +2568,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_GetState(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2590,7 +2590,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_IsTrainingCo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2616,7 +2616,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_Fit(/*in*/ H
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2643,7 +2643,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_FitBuffer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2664,7 +2664,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_OnDataComple
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2685,7 +2685,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CompleteTrai
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2703,7 +2703,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateTransf
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2713,7 +2713,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2729,7 +2729,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateTransf
         Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::uint64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::uint64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2739,7 +2739,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2763,7 +2763,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_DestroyTrans
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2796,7 +2796,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2827,7 +2827,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_Transform(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2848,10 +2848,10 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_DestroyTrans
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  HashOneHotVectorizerFeaturizer <float_t> */
+/* |  HashOneHotVectorizerFeaturizer <float> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2864,7 +2864,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateEstimat
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_float_EstimatorHandle*>(index);
 
 
     
@@ -2876,7 +2876,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateEstimat
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2899,7 +2899,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_DestroyEstima
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_GetState(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2921,7 +2921,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_GetState(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2943,7 +2943,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_IsTrainingCom
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_Fit(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2969,7 +2969,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_Fit(/*in*/ Ha
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2996,7 +2996,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_FitBuffer(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3017,7 +3017,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_OnDataComplet
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3038,7 +3038,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CompleteTrain
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3056,7 +3056,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateTransfo
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -3066,7 +3066,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3082,7 +3082,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateTransfo
         Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::float_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -3092,7 +3092,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3116,7 +3116,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_DestroyTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3149,7 +3149,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateTransfo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_Transform(/*in*/ HashOneHotVectorizerFeaturizer_float_TransformerHandle *pHandle, /*in*/ float input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3180,7 +3180,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_Transform(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3201,10 +3201,10 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_DestroyTransf
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  HashOneHotVectorizerFeaturizer <double_t> */
+/* |  HashOneHotVectorizerFeaturizer <double> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols, /*out*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3217,7 +3217,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateEstima
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_double_EstimatorHandle*>(index);
 
 
     
@@ -3229,7 +3229,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateEstima
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3252,7 +3252,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_DestroyEstim
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_GetState(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3274,7 +3274,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_GetState(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3296,7 +3296,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_IsTrainingCo
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_Fit(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3322,7 +3322,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_Fit(/*in*/ H
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3349,7 +3349,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_FitBuffer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3370,7 +3370,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_OnDataComple
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3391,7 +3391,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CompleteTrai
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3409,7 +3409,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateTransf
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3419,7 +3419,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3435,7 +3435,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateTransf
         Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::HashOneHotVectorizerEstimator<std::double_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<HashOneHotVectorizerFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3445,7 +3445,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3469,7 +3469,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_DestroyTrans
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3502,7 +3502,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateTransf
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_Transform(/*in*/ HashOneHotVectorizerFeaturizer_double_TransformerHandle *pHandle, /*in*/ double input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3533,7 +3533,7 @@ FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_Transform(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_HashOneHotVectorizerFeaturizer.h
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_HashOneHotVectorizerFeaturizer.h
@@ -19,264 +19,264 @@ FEATURIZER_LIBRARY_API_PACK_SUFFIX
 
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <int8_t> */
-struct HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle {};
-struct HashOneHotVectorizerFeaturizer_int8_t_TransformerHandle {};
+/* |  HashOneHotVectorizerFeaturizer <int8> */
+struct HashOneHotVectorizerFeaturizer_int8_EstimatorHandle {};
+struct HashOneHotVectorizerFeaturizer_int8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int8_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <int16_t> */
-struct HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle {};
-struct HashOneHotVectorizerFeaturizer_int16_t_TransformerHandle {};
+/* |  HashOneHotVectorizerFeaturizer <int16> */
+struct HashOneHotVectorizerFeaturizer_int16_EstimatorHandle {};
+struct HashOneHotVectorizerFeaturizer_int16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int16_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <int32_t> */
-struct HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle {};
-struct HashOneHotVectorizerFeaturizer_int32_t_TransformerHandle {};
+/* |  HashOneHotVectorizerFeaturizer <int32> */
+struct HashOneHotVectorizerFeaturizer_int32_EstimatorHandle {};
+struct HashOneHotVectorizerFeaturizer_int32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int32_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <int64_t> */
-struct HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle {};
-struct HashOneHotVectorizerFeaturizer_int64_t_TransformerHandle {};
+/* |  HashOneHotVectorizerFeaturizer <int64> */
+struct HashOneHotVectorizerFeaturizer_int64_EstimatorHandle {};
+struct HashOneHotVectorizerFeaturizer_int64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_GetState(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_Fit(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_Transform(/*in*/ HashOneHotVectorizerFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_int64_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <uint8_t> */
-struct HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle {};
-struct HashOneHotVectorizerFeaturizer_uint8_t_TransformerHandle {};
+/* |  HashOneHotVectorizerFeaturizer <uint8> */
+struct HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle {};
+struct HashOneHotVectorizerFeaturizer_uint8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint8_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <uint16_t> */
-struct HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle {};
-struct HashOneHotVectorizerFeaturizer_uint16_t_TransformerHandle {};
+/* |  HashOneHotVectorizerFeaturizer <uint16> */
+struct HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle {};
+struct HashOneHotVectorizerFeaturizer_uint16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint16_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <uint32_t> */
-struct HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle {};
-struct HashOneHotVectorizerFeaturizer_uint32_t_TransformerHandle {};
+/* |  HashOneHotVectorizerFeaturizer <uint32> */
+struct HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle {};
+struct HashOneHotVectorizerFeaturizer_uint32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint32_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <uint64_t> */
-struct HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle {};
-struct HashOneHotVectorizerFeaturizer_uint64_t_TransformerHandle {};
+/* |  HashOneHotVectorizerFeaturizer <uint64> */
+struct HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle {};
+struct HashOneHotVectorizerFeaturizer_uint64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_GetState(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_Fit(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_Transform(/*in*/ HashOneHotVectorizerFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_uint64_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <float_t> */
-struct HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle {};
-struct HashOneHotVectorizerFeaturizer_float_t_TransformerHandle {};
+/* |  HashOneHotVectorizerFeaturizer <float> */
+struct HashOneHotVectorizerFeaturizer_float_EstimatorHandle {};
+struct HashOneHotVectorizerFeaturizer_float_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_GetState(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_Fit(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_Transform(/*in*/ HashOneHotVectorizerFeaturizer_float_TransformerHandle *pHandle, /*in*/ float input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_float_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <double_t> */
-struct HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle {};
-struct HashOneHotVectorizerFeaturizer_double_t_TransformerHandle {};
+/* |  HashOneHotVectorizerFeaturizer <double> */
+struct HashOneHotVectorizerFeaturizer_double_EstimatorHandle {};
+struct HashOneHotVectorizerFeaturizer_double_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_CreateEstimator(/*in*/ uint32_t hashingSeedVal, /*in*/ uint32_t numCols,/*out*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_DestroyEstimator(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_GetState(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_Fit(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_GetState(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_IsTrainingComplete(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_Fit(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_FitBuffer(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_OnDataCompleted(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_CompleteTraining(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_CreateTransformerFromEstimator(/*in*/ HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ HashOneHotVectorizerFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ HashOneHotVectorizerFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_DestroyTransformer(/*in*/ HashOneHotVectorizerFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_CreateTransformerSaveData(/*in*/ HashOneHotVectorizerFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_Transform(/*in*/ HashOneHotVectorizerFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_t_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_Transform(/*in*/ HashOneHotVectorizerFeaturizer_double_TransformerHandle *pHandle, /*in*/ double input, /*out via struct*/ HashOneHotVectorizerStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool HashOneHotVectorizerFeaturizer_double_DestroyTransformedData(/*in*/ HashOneHotVectorizerStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
 /* |  HashOneHotVectorizerFeaturizer <bool> */

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_ImputationMarkerFeaturizer.cpp
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_ImputationMarkerFeaturizer.cpp
@@ -24,10 +24,10 @@ extern "C" {
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  ImputationMarkerFeaturizer <int8_t> */
+/* |  ImputationMarkerFeaturizer <int8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -40,7 +40,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateEstimator(/*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_int8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_int8_EstimatorHandle*>(index);
 
 
     
@@ -52,7 +52,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateEstimator(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -75,7 +75,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_DestroyEstimator(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_GetState(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_GetState(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -97,7 +97,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_GetState(/*in*/ Im
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -119,7 +119,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_IsTrainingComplete
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_Fit(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_Fit(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -145,7 +145,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_Fit(/*in*/ Imputat
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -187,7 +187,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_FitBuffer(/*in*/ I
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -208,7 +208,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_OnDataCompleted(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -229,7 +229,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CompleteTraining(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -247,7 +247,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateTransformerF
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -257,7 +257,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateTransformerF
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -273,7 +273,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateTransformerF
         Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::int8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::int8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -283,7 +283,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateTransformerF
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -307,7 +307,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_DestroyTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -340,7 +340,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateTransformerS
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_Transform(/*in*/ ImputationMarkerFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_Transform(/*in*/ ImputationMarkerFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -371,10 +371,10 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_Transform(/*in*/ I
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  ImputationMarkerFeaturizer <int16_t> */
+/* |  ImputationMarkerFeaturizer <int16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -387,7 +387,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateEstimator(/
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_int16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_int16_EstimatorHandle*>(index);
 
 
     
@@ -399,7 +399,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateEstimator(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -422,7 +422,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_DestroyEstimator(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_GetState(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_GetState(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -444,7 +444,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_GetState(/*in*/ I
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -466,7 +466,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_IsTrainingComplet
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_Fit(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_Fit(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -492,7 +492,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_Fit(/*in*/ Imputa
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -534,7 +534,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_FitBuffer(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -555,7 +555,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_OnDataCompleted(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -576,7 +576,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CompleteTraining(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -594,7 +594,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateTransformer
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -604,7 +604,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -620,7 +620,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateTransformer
         Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::int16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::int16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -630,7 +630,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -654,7 +654,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_DestroyTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -687,7 +687,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_Transform(/*in*/ ImputationMarkerFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_Transform(/*in*/ ImputationMarkerFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -718,10 +718,10 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_Transform(/*in*/ 
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  ImputationMarkerFeaturizer <int32_t> */
+/* |  ImputationMarkerFeaturizer <int32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -734,7 +734,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateEstimator(/
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_int32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_int32_EstimatorHandle*>(index);
 
 
     
@@ -746,7 +746,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateEstimator(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -769,7 +769,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_DestroyEstimator(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_GetState(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_GetState(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -791,7 +791,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_GetState(/*in*/ I
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -813,7 +813,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_IsTrainingComplet
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_Fit(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_Fit(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -839,7 +839,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_Fit(/*in*/ Imputa
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -881,7 +881,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_FitBuffer(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -902,7 +902,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_OnDataCompleted(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -923,7 +923,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CompleteTraining(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -941,7 +941,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateTransformer
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -951,7 +951,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -967,7 +967,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateTransformer
         Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::int32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::int32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -977,7 +977,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1001,7 +1001,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_DestroyTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1034,7 +1034,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_Transform(/*in*/ ImputationMarkerFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_Transform(/*in*/ ImputationMarkerFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1065,10 +1065,10 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_Transform(/*in*/ 
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  ImputationMarkerFeaturizer <int64_t> */
+/* |  ImputationMarkerFeaturizer <int64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1081,7 +1081,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateEstimator(/
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_int64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_int64_EstimatorHandle*>(index);
 
 
     
@@ -1093,7 +1093,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateEstimator(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1116,7 +1116,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_DestroyEstimator(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_GetState(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_GetState(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1138,7 +1138,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_GetState(/*in*/ I
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1160,7 +1160,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_IsTrainingComplet
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_Fit(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_Fit(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1186,7 +1186,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_Fit(/*in*/ Imputa
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1228,7 +1228,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_FitBuffer(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1249,7 +1249,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_OnDataCompleted(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1270,7 +1270,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CompleteTraining(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1288,7 +1288,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateTransformer
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1298,7 +1298,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1314,7 +1314,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateTransformer
         Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::int64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::int64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1324,7 +1324,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1348,7 +1348,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_DestroyTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1381,7 +1381,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_Transform(/*in*/ ImputationMarkerFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_Transform(/*in*/ ImputationMarkerFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1412,10 +1412,10 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_Transform(/*in*/ 
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  ImputationMarkerFeaturizer <uint8_t> */
+/* |  ImputationMarkerFeaturizer <uint8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1428,7 +1428,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateEstimator(/
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint8_EstimatorHandle*>(index);
 
 
     
@@ -1440,7 +1440,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateEstimator(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1463,7 +1463,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_DestroyEstimator(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_GetState(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_GetState(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1485,7 +1485,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_GetState(/*in*/ I
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1507,7 +1507,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_IsTrainingComplet
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_Fit(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_Fit(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1533,7 +1533,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_Fit(/*in*/ Imputa
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1575,7 +1575,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_FitBuffer(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1596,7 +1596,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_OnDataCompleted(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1617,7 +1617,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CompleteTraining(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1635,7 +1635,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateTransformer
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1645,7 +1645,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1661,7 +1661,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateTransformer
         Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::uint8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::uint8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1671,7 +1671,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1695,7 +1695,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_DestroyTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1728,7 +1728,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_Transform(/*in*/ ImputationMarkerFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_Transform(/*in*/ ImputationMarkerFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1759,10 +1759,10 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_Transform(/*in*/ 
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  ImputationMarkerFeaturizer <uint16_t> */
+/* |  ImputationMarkerFeaturizer <uint16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1775,7 +1775,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateEstimator(
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint16_EstimatorHandle*>(index);
 
 
     
@@ -1787,7 +1787,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateEstimator(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1810,7 +1810,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_DestroyEstimator
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_GetState(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_GetState(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1832,7 +1832,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_GetState(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1854,7 +1854,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_IsTrainingComple
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_Fit(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_Fit(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1880,7 +1880,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_Fit(/*in*/ Imput
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1922,7 +1922,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_FitBuffer(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1943,7 +1943,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_OnDataCompleted(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1964,7 +1964,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CompleteTraining
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1982,7 +1982,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateTransforme
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -1992,7 +1992,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2008,7 +2008,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateTransforme
         Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::uint16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::uint16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -2018,7 +2018,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2042,7 +2042,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_DestroyTransform
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2075,7 +2075,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_Transform(/*in*/ ImputationMarkerFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_Transform(/*in*/ ImputationMarkerFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2106,10 +2106,10 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_Transform(/*in*/
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  ImputationMarkerFeaturizer <uint32_t> */
+/* |  ImputationMarkerFeaturizer <uint32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2122,7 +2122,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateEstimator(
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint32_EstimatorHandle*>(index);
 
 
     
@@ -2134,7 +2134,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateEstimator(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2157,7 +2157,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_DestroyEstimator
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_GetState(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_GetState(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2179,7 +2179,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_GetState(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2201,7 +2201,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_IsTrainingComple
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_Fit(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_Fit(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2227,7 +2227,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_Fit(/*in*/ Imput
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2269,7 +2269,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_FitBuffer(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2290,7 +2290,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_OnDataCompleted(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2311,7 +2311,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CompleteTraining
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2329,7 +2329,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateTransforme
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2339,7 +2339,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2355,7 +2355,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateTransforme
         Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::uint32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::uint32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2365,7 +2365,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2389,7 +2389,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_DestroyTransform
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2422,7 +2422,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_Transform(/*in*/ ImputationMarkerFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_Transform(/*in*/ ImputationMarkerFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2453,10 +2453,10 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_Transform(/*in*/
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  ImputationMarkerFeaturizer <uint64_t> */
+/* |  ImputationMarkerFeaturizer <uint64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2469,7 +2469,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateEstimator(
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint64_EstimatorHandle*>(index);
 
 
     
@@ -2481,7 +2481,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateEstimator(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2504,7 +2504,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_DestroyEstimator
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_GetState(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_GetState(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2526,7 +2526,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_GetState(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2548,7 +2548,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_IsTrainingComple
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_Fit(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_Fit(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2574,7 +2574,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_Fit(/*in*/ Imput
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2616,7 +2616,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_FitBuffer(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2637,7 +2637,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_OnDataCompleted(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2658,7 +2658,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CompleteTraining
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2676,7 +2676,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateTransforme
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2686,7 +2686,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2702,7 +2702,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateTransforme
         Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::uint64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::uint64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2712,7 +2712,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2736,7 +2736,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_DestroyTransform
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2769,7 +2769,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_Transform(/*in*/ ImputationMarkerFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_Transform(/*in*/ ImputationMarkerFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2800,10 +2800,10 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_Transform(/*in*/
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  ImputationMarkerFeaturizer <float_t> */
+/* |  ImputationMarkerFeaturizer <float> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2816,7 +2816,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateEstimator(/
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_float_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_float_EstimatorHandle*>(index);
 
 
     
@@ -2828,7 +2828,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateEstimator(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2851,7 +2851,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_DestroyEstimator(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_GetState(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_GetState(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2873,7 +2873,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_GetState(/*in*/ I
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2895,7 +2895,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_IsTrainingComplet
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_Fit(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_Fit(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2921,7 +2921,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_Fit(/*in*/ Imputa
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_FitBuffer(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2963,7 +2963,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_FitBuffer(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2984,7 +2984,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_OnDataCompleted(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3005,7 +3005,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CompleteTraining(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3023,7 +3023,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateTransformer
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -3033,7 +3033,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3049,7 +3049,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateTransformer
         Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::float_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -3059,7 +3059,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3083,7 +3083,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_DestroyTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3116,7 +3116,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_Transform(/*in*/ ImputationMarkerFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_Transform(/*in*/ ImputationMarkerFeaturizer_float_TransformerHandle *pHandle, /*in*/ float const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3147,10 +3147,10 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_Transform(/*in*/ 
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  ImputationMarkerFeaturizer <double_t> */
+/* |  ImputationMarkerFeaturizer <double> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3163,7 +3163,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateEstimator(
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_double_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<ImputationMarkerFeaturizer_double_EstimatorHandle*>(index);
 
 
     
@@ -3175,7 +3175,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateEstimator(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3198,7 +3198,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_DestroyEstimator
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_GetState(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_GetState(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3220,7 +3220,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_GetState(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3242,7 +3242,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_IsTrainingComple
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_Fit(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_Fit(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3268,7 +3268,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_Fit(/*in*/ Imput
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_FitBuffer(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3310,7 +3310,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_FitBuffer(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3331,7 +3331,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_OnDataCompleted(
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3352,7 +3352,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CompleteTraining
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3370,7 +3370,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateTransforme
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3380,7 +3380,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3396,7 +3396,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateTransforme
         Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::ImputationMarkerEstimator<std::double_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<ImputationMarkerFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3406,7 +3406,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3430,7 +3430,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_DestroyTransform
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3463,7 +3463,7 @@ FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateTransforme
     }
 }
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_Transform(/*in*/ ImputationMarkerFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_Transform(/*in*/ ImputationMarkerFeaturizer_double_TransformerHandle *pHandle, /*in*/ double const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_ImputationMarkerFeaturizer.h
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_ImputationMarkerFeaturizer.h
@@ -9,254 +9,254 @@
 extern "C" {
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <int8_t> */
-struct ImputationMarkerFeaturizer_int8_t_EstimatorHandle {};
-struct ImputationMarkerFeaturizer_int8_t_TransformerHandle {};
+/* |  ImputationMarkerFeaturizer <int8> */
+struct ImputationMarkerFeaturizer_int8_EstimatorHandle {};
+struct ImputationMarkerFeaturizer_int8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_GetState(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_Fit(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_GetState(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_Fit(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_t_Transform(/*in*/ ImputationMarkerFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int8_Transform(/*in*/ ImputationMarkerFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <int16_t> */
-struct ImputationMarkerFeaturizer_int16_t_EstimatorHandle {};
-struct ImputationMarkerFeaturizer_int16_t_TransformerHandle {};
+/* |  ImputationMarkerFeaturizer <int16> */
+struct ImputationMarkerFeaturizer_int16_EstimatorHandle {};
+struct ImputationMarkerFeaturizer_int16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_GetState(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_Fit(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_GetState(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_Fit(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_t_Transform(/*in*/ ImputationMarkerFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int16_Transform(/*in*/ ImputationMarkerFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <int32_t> */
-struct ImputationMarkerFeaturizer_int32_t_EstimatorHandle {};
-struct ImputationMarkerFeaturizer_int32_t_TransformerHandle {};
+/* |  ImputationMarkerFeaturizer <int32> */
+struct ImputationMarkerFeaturizer_int32_EstimatorHandle {};
+struct ImputationMarkerFeaturizer_int32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_GetState(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_Fit(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_GetState(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_Fit(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_t_Transform(/*in*/ ImputationMarkerFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int32_Transform(/*in*/ ImputationMarkerFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <int64_t> */
-struct ImputationMarkerFeaturizer_int64_t_EstimatorHandle {};
-struct ImputationMarkerFeaturizer_int64_t_TransformerHandle {};
+/* |  ImputationMarkerFeaturizer <int64> */
+struct ImputationMarkerFeaturizer_int64_EstimatorHandle {};
+struct ImputationMarkerFeaturizer_int64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_GetState(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_Fit(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_GetState(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_Fit(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_FitBuffer(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_t_Transform(/*in*/ ImputationMarkerFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_int64_Transform(/*in*/ ImputationMarkerFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <uint8_t> */
-struct ImputationMarkerFeaturizer_uint8_t_EstimatorHandle {};
-struct ImputationMarkerFeaturizer_uint8_t_TransformerHandle {};
+/* |  ImputationMarkerFeaturizer <uint8> */
+struct ImputationMarkerFeaturizer_uint8_EstimatorHandle {};
+struct ImputationMarkerFeaturizer_uint8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_GetState(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_Fit(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_GetState(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_Fit(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_t_Transform(/*in*/ ImputationMarkerFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint8_Transform(/*in*/ ImputationMarkerFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <uint16_t> */
-struct ImputationMarkerFeaturizer_uint16_t_EstimatorHandle {};
-struct ImputationMarkerFeaturizer_uint16_t_TransformerHandle {};
+/* |  ImputationMarkerFeaturizer <uint16> */
+struct ImputationMarkerFeaturizer_uint16_EstimatorHandle {};
+struct ImputationMarkerFeaturizer_uint16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_GetState(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_Fit(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_GetState(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_Fit(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_t_Transform(/*in*/ ImputationMarkerFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint16_Transform(/*in*/ ImputationMarkerFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <uint32_t> */
-struct ImputationMarkerFeaturizer_uint32_t_EstimatorHandle {};
-struct ImputationMarkerFeaturizer_uint32_t_TransformerHandle {};
+/* |  ImputationMarkerFeaturizer <uint32> */
+struct ImputationMarkerFeaturizer_uint32_EstimatorHandle {};
+struct ImputationMarkerFeaturizer_uint32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_GetState(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_Fit(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_GetState(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_Fit(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_t_Transform(/*in*/ ImputationMarkerFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint32_Transform(/*in*/ ImputationMarkerFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <uint64_t> */
-struct ImputationMarkerFeaturizer_uint64_t_EstimatorHandle {};
-struct ImputationMarkerFeaturizer_uint64_t_TransformerHandle {};
+/* |  ImputationMarkerFeaturizer <uint64> */
+struct ImputationMarkerFeaturizer_uint64_EstimatorHandle {};
+struct ImputationMarkerFeaturizer_uint64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_GetState(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_Fit(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_GetState(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_Fit(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_FitBuffer(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_t_Transform(/*in*/ ImputationMarkerFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_uint64_Transform(/*in*/ ImputationMarkerFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <float_t> */
-struct ImputationMarkerFeaturizer_float_t_EstimatorHandle {};
-struct ImputationMarkerFeaturizer_float_t_TransformerHandle {};
+/* |  ImputationMarkerFeaturizer <float> */
+struct ImputationMarkerFeaturizer_float_EstimatorHandle {};
+struct ImputationMarkerFeaturizer_float_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_GetState(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_Fit(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_GetState(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_Fit(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_FitBuffer(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_t_Transform(/*in*/ ImputationMarkerFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_float_Transform(/*in*/ ImputationMarkerFeaturizer_float_TransformerHandle *pHandle, /*in*/ float const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <double_t> */
-struct ImputationMarkerFeaturizer_double_t_EstimatorHandle {};
-struct ImputationMarkerFeaturizer_double_t_TransformerHandle {};
+/* |  ImputationMarkerFeaturizer <double> */
+struct ImputationMarkerFeaturizer_double_EstimatorHandle {};
+struct ImputationMarkerFeaturizer_double_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_CreateEstimator(/*out*/ ImputationMarkerFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_DestroyEstimator(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_GetState(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_Fit(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_FitBuffer(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_GetState(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_IsTrainingComplete(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_Fit(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_FitBuffer(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_OnDataCompleted(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_CompleteTraining(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_CreateTransformerFromEstimator(/*in*/ ImputationMarkerFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ ImputationMarkerFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ ImputationMarkerFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_DestroyTransformer(/*in*/ ImputationMarkerFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_CreateTransformerSaveData(/*in*/ ImputationMarkerFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_t_Transform(/*in*/ ImputationMarkerFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool ImputationMarkerFeaturizer_double_Transform(/*in*/ ImputationMarkerFeaturizer_double_TransformerHandle *pHandle, /*in*/ double const * input, /*out*/ bool * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
 /* |  ImputationMarkerFeaturizer <bool> */

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_LabelEncoderFeaturizer.cpp
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_LabelEncoderFeaturizer.cpp
@@ -24,10 +24,10 @@ extern "C" {
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  LabelEncoderFeaturizer <int8_t> */
+/* |  LabelEncoderFeaturizer <int8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -40,7 +40,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateEstimator(/*in*/
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_int8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_int8_EstimatorHandle*>(index);
 
 
     
@@ -52,7 +52,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateEstimator(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -75,7 +75,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_DestroyEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_GetState(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_GetState(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -97,7 +97,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_GetState(/*in*/ LabelE
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -119,7 +119,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_IsTrainingComplete(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_Fit(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_Fit(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -145,7 +145,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_Fit(/*in*/ LabelEncode
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_FitBuffer(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -172,7 +172,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_FitBuffer(/*in*/ Label
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -193,7 +193,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_OnDataCompleted(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -214,7 +214,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CompleteTraining(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -232,7 +232,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateTransformerFromE
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -242,7 +242,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateTransformerFromE
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -258,7 +258,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateTransformerFromS
         Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::int8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::int8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -268,7 +268,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateTransformerFromS
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -292,7 +292,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_DestroyTransformer(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -325,7 +325,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateTransformerSaveD
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_Transform(/*in*/ LabelEncoderFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_Transform(/*in*/ LabelEncoderFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -356,10 +356,10 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_Transform(/*in*/ Label
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  LabelEncoderFeaturizer <int16_t> */
+/* |  LabelEncoderFeaturizer <int16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -372,7 +372,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateEstimator(/*in*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_int16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_int16_EstimatorHandle*>(index);
 
 
     
@@ -384,7 +384,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -407,7 +407,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_GetState(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_GetState(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -429,7 +429,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_GetState(/*in*/ Label
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -451,7 +451,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_Fit(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_Fit(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -477,7 +477,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_Fit(/*in*/ LabelEncod
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_FitBuffer(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -504,7 +504,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_FitBuffer(/*in*/ Labe
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -525,7 +525,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -546,7 +546,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -564,7 +564,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateTransformerFrom
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -574,7 +574,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -590,7 +590,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateTransformerFrom
         Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::int16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::int16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -600,7 +600,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -624,7 +624,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -657,7 +657,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_Transform(/*in*/ LabelEncoderFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_Transform(/*in*/ LabelEncoderFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -688,10 +688,10 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_Transform(/*in*/ Labe
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  LabelEncoderFeaturizer <int32_t> */
+/* |  LabelEncoderFeaturizer <int32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -704,7 +704,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateEstimator(/*in*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_int32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_int32_EstimatorHandle*>(index);
 
 
     
@@ -716,7 +716,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -739,7 +739,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_GetState(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_GetState(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -761,7 +761,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_GetState(/*in*/ Label
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -783,7 +783,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_Fit(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_Fit(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -809,7 +809,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_Fit(/*in*/ LabelEncod
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_FitBuffer(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -836,7 +836,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_FitBuffer(/*in*/ Labe
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -857,7 +857,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -878,7 +878,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -896,7 +896,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateTransformerFrom
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -906,7 +906,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -922,7 +922,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateTransformerFrom
         Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::int32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::int32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -932,7 +932,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -956,7 +956,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -989,7 +989,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_Transform(/*in*/ LabelEncoderFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_Transform(/*in*/ LabelEncoderFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1020,10 +1020,10 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_Transform(/*in*/ Labe
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  LabelEncoderFeaturizer <int64_t> */
+/* |  LabelEncoderFeaturizer <int64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1036,7 +1036,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateEstimator(/*in*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_int64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_int64_EstimatorHandle*>(index);
 
 
     
@@ -1048,7 +1048,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1071,7 +1071,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_GetState(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_GetState(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1093,7 +1093,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_GetState(/*in*/ Label
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1115,7 +1115,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_Fit(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_Fit(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1141,7 +1141,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_Fit(/*in*/ LabelEncod
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_FitBuffer(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1168,7 +1168,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_FitBuffer(/*in*/ Labe
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1189,7 +1189,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1210,7 +1210,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1228,7 +1228,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateTransformerFrom
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1238,7 +1238,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1254,7 +1254,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateTransformerFrom
         Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::int64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::int64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1264,7 +1264,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1288,7 +1288,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1321,7 +1321,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_Transform(/*in*/ LabelEncoderFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_Transform(/*in*/ LabelEncoderFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1352,10 +1352,10 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_Transform(/*in*/ Labe
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  LabelEncoderFeaturizer <uint8_t> */
+/* |  LabelEncoderFeaturizer <uint8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1368,7 +1368,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateEstimator(/*in*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_uint8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_uint8_EstimatorHandle*>(index);
 
 
     
@@ -1380,7 +1380,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1403,7 +1403,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_GetState(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_GetState(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1425,7 +1425,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_GetState(/*in*/ Label
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1447,7 +1447,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_Fit(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_Fit(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1473,7 +1473,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_Fit(/*in*/ LabelEncod
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1500,7 +1500,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_FitBuffer(/*in*/ Labe
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1521,7 +1521,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1542,7 +1542,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1560,7 +1560,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateTransformerFrom
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1570,7 +1570,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1586,7 +1586,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateTransformerFrom
         Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::uint8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::uint8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1596,7 +1596,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1620,7 +1620,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1653,7 +1653,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_Transform(/*in*/ LabelEncoderFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_Transform(/*in*/ LabelEncoderFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1684,10 +1684,10 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_Transform(/*in*/ Labe
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  LabelEncoderFeaturizer <uint16_t> */
+/* |  LabelEncoderFeaturizer <uint16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1700,7 +1700,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateEstimator(/*in
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_uint16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_uint16_EstimatorHandle*>(index);
 
 
     
@@ -1712,7 +1712,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1735,7 +1735,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_GetState(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_GetState(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1757,7 +1757,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_GetState(/*in*/ Labe
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1779,7 +1779,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_Fit(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_Fit(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1805,7 +1805,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_Fit(/*in*/ LabelEnco
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1832,7 +1832,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_FitBuffer(/*in*/ Lab
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1853,7 +1853,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1874,7 +1874,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1892,7 +1892,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateTransformerFro
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -1902,7 +1902,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1918,7 +1918,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateTransformerFro
         Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::uint16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::uint16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -1928,7 +1928,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1952,7 +1952,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1985,7 +1985,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_Transform(/*in*/ LabelEncoderFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_Transform(/*in*/ LabelEncoderFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2016,10 +2016,10 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_Transform(/*in*/ Lab
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  LabelEncoderFeaturizer <uint32_t> */
+/* |  LabelEncoderFeaturizer <uint32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2032,7 +2032,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateEstimator(/*in
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_uint32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_uint32_EstimatorHandle*>(index);
 
 
     
@@ -2044,7 +2044,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2067,7 +2067,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_GetState(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_GetState(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2089,7 +2089,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_GetState(/*in*/ Labe
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2111,7 +2111,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_Fit(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_Fit(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2137,7 +2137,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_Fit(/*in*/ LabelEnco
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2164,7 +2164,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_FitBuffer(/*in*/ Lab
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2185,7 +2185,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2206,7 +2206,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2224,7 +2224,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateTransformerFro
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2234,7 +2234,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2250,7 +2250,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateTransformerFro
         Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::uint32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::uint32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2260,7 +2260,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2284,7 +2284,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2317,7 +2317,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_Transform(/*in*/ LabelEncoderFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_Transform(/*in*/ LabelEncoderFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2348,10 +2348,10 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_Transform(/*in*/ Lab
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  LabelEncoderFeaturizer <uint64_t> */
+/* |  LabelEncoderFeaturizer <uint64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2364,7 +2364,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateEstimator(/*in
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_uint64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_uint64_EstimatorHandle*>(index);
 
 
     
@@ -2376,7 +2376,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2399,7 +2399,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_GetState(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_GetState(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2421,7 +2421,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_GetState(/*in*/ Labe
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2443,7 +2443,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_Fit(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_Fit(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2469,7 +2469,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_Fit(/*in*/ LabelEnco
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2496,7 +2496,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_FitBuffer(/*in*/ Lab
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2517,7 +2517,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2538,7 +2538,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2556,7 +2556,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateTransformerFro
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2566,7 +2566,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2582,7 +2582,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateTransformerFro
         Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::uint64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::uint64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2592,7 +2592,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2616,7 +2616,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2649,7 +2649,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_Transform(/*in*/ LabelEncoderFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_Transform(/*in*/ LabelEncoderFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2680,10 +2680,10 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_Transform(/*in*/ Lab
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  LabelEncoderFeaturizer <float_t> */
+/* |  LabelEncoderFeaturizer <float> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2696,7 +2696,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateEstimator(/*in*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_float_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_float_EstimatorHandle*>(index);
 
 
     
@@ -2708,7 +2708,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2731,7 +2731,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_GetState(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_GetState(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2753,7 +2753,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_GetState(/*in*/ Label
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2775,7 +2775,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_Fit(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_Fit(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2801,7 +2801,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_Fit(/*in*/ LabelEncod
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_FitBuffer(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2828,7 +2828,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_FitBuffer(/*in*/ Labe
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2849,7 +2849,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_CompleteTraining(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2870,7 +2870,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2888,7 +2888,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateTransformerFrom
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -2898,7 +2898,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2914,7 +2914,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateTransformerFrom
         Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::float_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -2924,7 +2924,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2948,7 +2948,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2981,7 +2981,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_Transform(/*in*/ LabelEncoderFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_Transform(/*in*/ LabelEncoderFeaturizer_float_TransformerHandle *pHandle, /*in*/ float input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3012,10 +3012,10 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_Transform(/*in*/ Labe
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  LabelEncoderFeaturizer <double_t> */
+/* |  LabelEncoderFeaturizer <double> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ LabelEncoderFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3028,7 +3028,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateEstimator(/*in
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_double_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<LabelEncoderFeaturizer_double_EstimatorHandle*>(index);
 
 
     
@@ -3040,7 +3040,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3063,7 +3063,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_GetState(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_GetState(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3085,7 +3085,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_GetState(/*in*/ Labe
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3107,7 +3107,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_Fit(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_Fit(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3133,7 +3133,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_Fit(/*in*/ LabelEnco
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_FitBuffer(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3160,7 +3160,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_FitBuffer(/*in*/ Lab
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3181,7 +3181,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_CompleteTraining(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3202,7 +3202,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3220,7 +3220,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateTransformerFro
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3230,7 +3230,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3246,7 +3246,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateTransformerFro
         Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::LabelEncoderEstimator<std::double_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<LabelEncoderFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3256,7 +3256,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3280,7 +3280,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3313,7 +3313,7 @@ FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_Transform(/*in*/ LabelEncoderFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_Transform(/*in*/ LabelEncoderFeaturizer_double_TransformerHandle *pHandle, /*in*/ double input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_LabelEncoderFeaturizer.h
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_LabelEncoderFeaturizer.h
@@ -9,254 +9,254 @@
 extern "C" {
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <int8_t> */
-struct LabelEncoderFeaturizer_int8_t_EstimatorHandle {};
-struct LabelEncoderFeaturizer_int8_t_TransformerHandle {};
+/* |  LabelEncoderFeaturizer <int8> */
+struct LabelEncoderFeaturizer_int8_EstimatorHandle {};
+struct LabelEncoderFeaturizer_int8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_GetState(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_Fit(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_GetState(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_Fit(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_FitBuffer(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_t_Transform(/*in*/ LabelEncoderFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int8_Transform(/*in*/ LabelEncoderFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <int16_t> */
-struct LabelEncoderFeaturizer_int16_t_EstimatorHandle {};
-struct LabelEncoderFeaturizer_int16_t_TransformerHandle {};
+/* |  LabelEncoderFeaturizer <int16> */
+struct LabelEncoderFeaturizer_int16_EstimatorHandle {};
+struct LabelEncoderFeaturizer_int16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_GetState(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_Fit(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_GetState(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_Fit(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_FitBuffer(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_t_Transform(/*in*/ LabelEncoderFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int16_Transform(/*in*/ LabelEncoderFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <int32_t> */
-struct LabelEncoderFeaturizer_int32_t_EstimatorHandle {};
-struct LabelEncoderFeaturizer_int32_t_TransformerHandle {};
+/* |  LabelEncoderFeaturizer <int32> */
+struct LabelEncoderFeaturizer_int32_EstimatorHandle {};
+struct LabelEncoderFeaturizer_int32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_GetState(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_Fit(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_GetState(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_Fit(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_FitBuffer(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_t_Transform(/*in*/ LabelEncoderFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int32_Transform(/*in*/ LabelEncoderFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <int64_t> */
-struct LabelEncoderFeaturizer_int64_t_EstimatorHandle {};
-struct LabelEncoderFeaturizer_int64_t_TransformerHandle {};
+/* |  LabelEncoderFeaturizer <int64> */
+struct LabelEncoderFeaturizer_int64_EstimatorHandle {};
+struct LabelEncoderFeaturizer_int64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_GetState(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_Fit(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_GetState(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_Fit(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_FitBuffer(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_CompleteTraining(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_t_Transform(/*in*/ LabelEncoderFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_int64_Transform(/*in*/ LabelEncoderFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <uint8_t> */
-struct LabelEncoderFeaturizer_uint8_t_EstimatorHandle {};
-struct LabelEncoderFeaturizer_uint8_t_TransformerHandle {};
+/* |  LabelEncoderFeaturizer <uint8> */
+struct LabelEncoderFeaturizer_uint8_EstimatorHandle {};
+struct LabelEncoderFeaturizer_uint8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_GetState(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_Fit(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_GetState(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_Fit(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_t_Transform(/*in*/ LabelEncoderFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint8_Transform(/*in*/ LabelEncoderFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <uint16_t> */
-struct LabelEncoderFeaturizer_uint16_t_EstimatorHandle {};
-struct LabelEncoderFeaturizer_uint16_t_TransformerHandle {};
+/* |  LabelEncoderFeaturizer <uint16> */
+struct LabelEncoderFeaturizer_uint16_EstimatorHandle {};
+struct LabelEncoderFeaturizer_uint16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_GetState(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_Fit(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_GetState(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_Fit(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_t_Transform(/*in*/ LabelEncoderFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint16_Transform(/*in*/ LabelEncoderFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <uint32_t> */
-struct LabelEncoderFeaturizer_uint32_t_EstimatorHandle {};
-struct LabelEncoderFeaturizer_uint32_t_TransformerHandle {};
+/* |  LabelEncoderFeaturizer <uint32> */
+struct LabelEncoderFeaturizer_uint32_EstimatorHandle {};
+struct LabelEncoderFeaturizer_uint32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_GetState(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_Fit(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_GetState(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_Fit(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_t_Transform(/*in*/ LabelEncoderFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint32_Transform(/*in*/ LabelEncoderFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <uint64_t> */
-struct LabelEncoderFeaturizer_uint64_t_EstimatorHandle {};
-struct LabelEncoderFeaturizer_uint64_t_TransformerHandle {};
+/* |  LabelEncoderFeaturizer <uint64> */
+struct LabelEncoderFeaturizer_uint64_EstimatorHandle {};
+struct LabelEncoderFeaturizer_uint64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_GetState(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_Fit(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_GetState(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_Fit(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_FitBuffer(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_CompleteTraining(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_t_Transform(/*in*/ LabelEncoderFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_uint64_Transform(/*in*/ LabelEncoderFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <float_t> */
-struct LabelEncoderFeaturizer_float_t_EstimatorHandle {};
-struct LabelEncoderFeaturizer_float_t_TransformerHandle {};
+/* |  LabelEncoderFeaturizer <float> */
+struct LabelEncoderFeaturizer_float_EstimatorHandle {};
+struct LabelEncoderFeaturizer_float_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_GetState(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_Fit(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_GetState(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_Fit(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_FitBuffer(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_CompleteTraining(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_t_Transform(/*in*/ LabelEncoderFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_float_Transform(/*in*/ LabelEncoderFeaturizer_float_TransformerHandle *pHandle, /*in*/ float input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <double_t> */
-struct LabelEncoderFeaturizer_double_t_EstimatorHandle {};
-struct LabelEncoderFeaturizer_double_t_TransformerHandle {};
+/* |  LabelEncoderFeaturizer <double> */
+struct LabelEncoderFeaturizer_double_EstimatorHandle {};
+struct LabelEncoderFeaturizer_double_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ LabelEncoderFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_DestroyEstimator(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_GetState(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_Fit(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_FitBuffer(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CompleteTraining(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_GetState(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_IsTrainingComplete(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_Fit(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_FitBuffer(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_OnDataCompleted(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_CompleteTraining(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_CreateTransformerFromEstimator(/*in*/ LabelEncoderFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ LabelEncoderFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ LabelEncoderFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_DestroyTransformer(/*in*/ LabelEncoderFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_CreateTransformerSaveData(/*in*/ LabelEncoderFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_t_Transform(/*in*/ LabelEncoderFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool LabelEncoderFeaturizer_double_Transform(/*in*/ LabelEncoderFeaturizer_double_TransformerHandle *pHandle, /*in*/ double input, /*out*/ uint32_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
 /* |  LabelEncoderFeaturizer <bool> */

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_MaxAbsScalarFeaturizer.cpp
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_MaxAbsScalarFeaturizer.cpp
@@ -24,10 +24,10 @@ extern "C" {
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MaxAbsScalarFeaturizer <int8_t> */
+/* |  MaxAbsScalarFeaturizer <int8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -35,12 +35,12 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateEstimator(/*out*
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int8_EstimatorHandle*>(index);
 
 
     
@@ -52,7 +52,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateEstimator(/*out*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -62,7 +62,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_DestroyEstimator(/*in*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -75,7 +75,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_DestroyEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_GetState(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_GetState(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -85,7 +85,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_GetState(/*in*/ MaxAbs
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -97,7 +97,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_GetState(/*in*/ MaxAbs
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -107,7 +107,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_IsTrainingComplete(/*i
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -119,7 +119,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_IsTrainingComplete(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_Fit(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_Fit(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -132,7 +132,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_Fit(/*in*/ MaxAbsScala
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -145,7 +145,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_Fit(/*in*/ MaxAbsScala
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -160,7 +160,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_FitBuffer(/*in*/ MaxAb
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -172,7 +172,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_FitBuffer(/*in*/ MaxAb
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -181,7 +181,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_OnDataCompleted(/*in*/
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -193,7 +193,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_OnDataCompleted(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -202,7 +202,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CompleteTraining(/*in*
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -214,7 +214,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CompleteTraining(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -226,13 +226,13 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateTransformerFromE
 
 
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -242,7 +242,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateTransformerFromE
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -255,10 +255,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateTransformerFromS
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -268,7 +268,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateTransformerFromS
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -278,7 +278,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_DestroyTransformer(/*i
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -292,7 +292,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_DestroyTransformer(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -303,7 +303,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateTransformerSaveD
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -325,7 +325,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateTransformerSaveD
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_Transform(/*in*/ MaxAbsScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_Transform(/*in*/ MaxAbsScalarFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -338,7 +338,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_Transform(/*in*/ MaxAb
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int8_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -356,10 +356,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_Transform(/*in*/ MaxAb
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MaxAbsScalarFeaturizer <int16_t> */
+/* |  MaxAbsScalarFeaturizer <int16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -367,12 +367,12 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateEstimator(/*out
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int16_EstimatorHandle*>(index);
 
 
     
@@ -384,7 +384,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateEstimator(/*out
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -394,7 +394,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_DestroyEstimator(/*in
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -407,7 +407,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_GetState(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_GetState(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -417,7 +417,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_GetState(/*in*/ MaxAb
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -429,7 +429,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_GetState(/*in*/ MaxAb
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -439,7 +439,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_IsTrainingComplete(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -451,7 +451,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_Fit(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_Fit(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -464,7 +464,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_Fit(/*in*/ MaxAbsScal
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -477,7 +477,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_Fit(/*in*/ MaxAbsScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -492,7 +492,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_FitBuffer(/*in*/ MaxA
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -504,7 +504,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_FitBuffer(/*in*/ MaxA
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -513,7 +513,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_OnDataCompleted(/*in*
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -525,7 +525,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -534,7 +534,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CompleteTraining(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -546,7 +546,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -558,13 +558,13 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateTransformerFrom
 
 
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -574,7 +574,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -587,10 +587,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateTransformerFrom
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -600,7 +600,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -610,7 +610,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_DestroyTransformer(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -624,7 +624,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -635,7 +635,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateTransformerSave
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -657,7 +657,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_Transform(/*in*/ MaxAbsScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_Transform(/*in*/ MaxAbsScalarFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -670,7 +670,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_Transform(/*in*/ MaxA
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int16_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -688,10 +688,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_Transform(/*in*/ MaxA
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MaxAbsScalarFeaturizer <uint8_t> */
+/* |  MaxAbsScalarFeaturizer <uint8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -699,12 +699,12 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateEstimator(/*out
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint8_EstimatorHandle*>(index);
 
 
     
@@ -716,7 +716,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateEstimator(/*out
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -726,7 +726,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_DestroyEstimator(/*in
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -739,7 +739,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_GetState(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_GetState(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -749,7 +749,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_GetState(/*in*/ MaxAb
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -761,7 +761,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_GetState(/*in*/ MaxAb
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -771,7 +771,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_IsTrainingComplete(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -783,7 +783,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_Fit(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_Fit(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -796,7 +796,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_Fit(/*in*/ MaxAbsScal
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -809,7 +809,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_Fit(/*in*/ MaxAbsScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -824,7 +824,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_FitBuffer(/*in*/ MaxA
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -836,7 +836,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_FitBuffer(/*in*/ MaxA
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -845,7 +845,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_OnDataCompleted(/*in*
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -857,7 +857,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -866,7 +866,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CompleteTraining(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -878,7 +878,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -890,13 +890,13 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateTransformerFrom
 
 
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -906,7 +906,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -919,10 +919,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateTransformerFrom
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -932,7 +932,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -942,7 +942,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_DestroyTransformer(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -956,7 +956,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -967,7 +967,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateTransformerSave
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -989,7 +989,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_Transform(/*in*/ MaxAbsScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_Transform(/*in*/ MaxAbsScalarFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1002,7 +1002,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_Transform(/*in*/ MaxA
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint8_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -1020,10 +1020,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_Transform(/*in*/ MaxA
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MaxAbsScalarFeaturizer <uint16_t> */
+/* |  MaxAbsScalarFeaturizer <uint16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1031,12 +1031,12 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateEstimator(/*ou
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint16_EstimatorHandle*>(index);
 
 
     
@@ -1048,7 +1048,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateEstimator(/*ou
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1058,7 +1058,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_DestroyEstimator(/*i
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -1071,7 +1071,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_GetState(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_GetState(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1081,7 +1081,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_GetState(/*in*/ MaxA
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -1093,7 +1093,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_GetState(/*in*/ MaxA
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1103,7 +1103,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_IsTrainingComplete(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -1115,7 +1115,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_Fit(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_Fit(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1128,7 +1128,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_Fit(/*in*/ MaxAbsSca
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -1141,7 +1141,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_Fit(/*in*/ MaxAbsSca
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1156,7 +1156,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_FitBuffer(/*in*/ Max
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -1168,7 +1168,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_FitBuffer(/*in*/ Max
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1177,7 +1177,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_OnDataCompleted(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -1189,7 +1189,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1198,7 +1198,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CompleteTraining(/*i
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -1210,7 +1210,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1222,13 +1222,13 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateTransformerFro
 
 
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -1238,7 +1238,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1251,10 +1251,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateTransformerFro
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -1264,7 +1264,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1274,7 +1274,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_DestroyTransformer(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -1288,7 +1288,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1299,7 +1299,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateTransformerSav
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -1321,7 +1321,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_Transform(/*in*/ MaxAbsScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_Transform(/*in*/ MaxAbsScalarFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1334,7 +1334,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_Transform(/*in*/ Max
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint16_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -1352,10 +1352,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_Transform(/*in*/ Max
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MaxAbsScalarFeaturizer <float_t> */
+/* |  MaxAbsScalarFeaturizer <float> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1363,12 +1363,12 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateEstimator(/*out
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_float_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_float_EstimatorHandle*>(index);
 
 
     
@@ -1380,7 +1380,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateEstimator(/*out
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1390,7 +1390,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_DestroyEstimator(/*in
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -1403,7 +1403,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_GetState(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_GetState(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1413,7 +1413,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_GetState(/*in*/ MaxAb
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -1425,7 +1425,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_GetState(/*in*/ MaxAb
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1435,7 +1435,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_IsTrainingComplete(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -1447,7 +1447,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_Fit(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_Fit(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1460,7 +1460,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_Fit(/*in*/ MaxAbsScal
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -1473,7 +1473,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_Fit(/*in*/ MaxAbsScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1488,7 +1488,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_FitBuffer(/*in*/ MaxA
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -1500,7 +1500,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_FitBuffer(/*in*/ MaxA
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1509,7 +1509,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_OnDataCompleted(/*in*
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -1521,7 +1521,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1530,7 +1530,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CompleteTraining(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -1542,7 +1542,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1554,13 +1554,13 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateTransformerFrom
 
 
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -1570,7 +1570,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1583,10 +1583,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateTransformerFrom
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -1596,7 +1596,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1606,7 +1606,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_DestroyTransformer(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -1620,7 +1620,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1631,7 +1631,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateTransformerSave
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -1653,7 +1653,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_Transform(/*in*/ MaxAbsScalarFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_Transform(/*in*/ MaxAbsScalarFeaturizer_float_TransformerHandle *pHandle, /*in*/ float input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1666,7 +1666,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_Transform(/*in*/ MaxA
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::float_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -1684,10 +1684,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_Transform(/*in*/ MaxA
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MaxAbsScalarFeaturizer <int32_t> */
+/* |  MaxAbsScalarFeaturizer <int32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1695,12 +1695,12 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateEstimator(/*out
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int32_EstimatorHandle*>(index);
 
 
     
@@ -1712,7 +1712,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateEstimator(/*out
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1722,7 +1722,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_DestroyEstimator(/*in
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -1735,7 +1735,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_GetState(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_GetState(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1745,7 +1745,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_GetState(/*in*/ MaxAb
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -1757,7 +1757,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_GetState(/*in*/ MaxAb
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1767,7 +1767,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_IsTrainingComplete(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -1779,7 +1779,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_Fit(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_Fit(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1792,7 +1792,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_Fit(/*in*/ MaxAbsScal
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -1805,7 +1805,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_Fit(/*in*/ MaxAbsScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1820,7 +1820,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_FitBuffer(/*in*/ MaxA
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -1832,7 +1832,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_FitBuffer(/*in*/ MaxA
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1841,7 +1841,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_OnDataCompleted(/*in*
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -1853,7 +1853,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1862,7 +1862,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CompleteTraining(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -1874,7 +1874,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1886,13 +1886,13 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateTransformerFrom
 
 
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -1902,7 +1902,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1915,10 +1915,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateTransformerFrom
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -1928,7 +1928,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1938,7 +1938,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_DestroyTransformer(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -1952,7 +1952,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1963,7 +1963,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateTransformerSave
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -1985,7 +1985,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_Transform(/*in*/ MaxAbsScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_Transform(/*in*/ MaxAbsScalarFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1998,7 +1998,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_Transform(/*in*/ MaxA
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int32_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -2016,10 +2016,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_Transform(/*in*/ MaxA
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MaxAbsScalarFeaturizer <int64_t> */
+/* |  MaxAbsScalarFeaturizer <int64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2027,12 +2027,12 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateEstimator(/*out
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int64_EstimatorHandle*>(index);
 
 
     
@@ -2044,7 +2044,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateEstimator(/*out
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2054,7 +2054,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_DestroyEstimator(/*in
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -2067,7 +2067,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_GetState(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_GetState(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2077,7 +2077,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_GetState(/*in*/ MaxAb
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -2089,7 +2089,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_GetState(/*in*/ MaxAb
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2099,7 +2099,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_IsTrainingComplete(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -2111,7 +2111,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_Fit(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_Fit(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2124,7 +2124,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_Fit(/*in*/ MaxAbsScal
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -2137,7 +2137,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_Fit(/*in*/ MaxAbsScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2152,7 +2152,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_FitBuffer(/*in*/ MaxA
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -2164,7 +2164,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_FitBuffer(/*in*/ MaxA
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2173,7 +2173,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_OnDataCompleted(/*in*
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -2185,7 +2185,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2194,7 +2194,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CompleteTraining(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -2206,7 +2206,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2218,13 +2218,13 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateTransformerFrom
 
 
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2234,7 +2234,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2247,10 +2247,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateTransformerFrom
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2260,7 +2260,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2270,7 +2270,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_DestroyTransformer(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -2284,7 +2284,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2295,7 +2295,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateTransformerSave
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -2317,7 +2317,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_Transform(/*in*/ MaxAbsScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_Transform(/*in*/ MaxAbsScalarFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2330,7 +2330,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_Transform(/*in*/ MaxA
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::int64_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -2348,10 +2348,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_Transform(/*in*/ MaxA
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MaxAbsScalarFeaturizer <uint32_t> */
+/* |  MaxAbsScalarFeaturizer <uint32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2359,12 +2359,12 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateEstimator(/*ou
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint32_EstimatorHandle*>(index);
 
 
     
@@ -2376,7 +2376,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateEstimator(/*ou
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2386,7 +2386,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_DestroyEstimator(/*i
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -2399,7 +2399,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_GetState(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_GetState(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2409,7 +2409,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_GetState(/*in*/ MaxA
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -2421,7 +2421,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_GetState(/*in*/ MaxA
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2431,7 +2431,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_IsTrainingComplete(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -2443,7 +2443,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_Fit(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_Fit(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2456,7 +2456,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_Fit(/*in*/ MaxAbsSca
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -2469,7 +2469,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_Fit(/*in*/ MaxAbsSca
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2484,7 +2484,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_FitBuffer(/*in*/ Max
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -2496,7 +2496,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_FitBuffer(/*in*/ Max
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2505,7 +2505,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_OnDataCompleted(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -2517,7 +2517,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2526,7 +2526,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CompleteTraining(/*i
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -2538,7 +2538,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2550,13 +2550,13 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateTransformerFro
 
 
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2566,7 +2566,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2579,10 +2579,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateTransformerFro
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2592,7 +2592,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2602,7 +2602,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_DestroyTransformer(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -2616,7 +2616,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2627,7 +2627,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateTransformerSav
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -2649,7 +2649,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_Transform(/*in*/ MaxAbsScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_Transform(/*in*/ MaxAbsScalarFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2662,7 +2662,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_Transform(/*in*/ Max
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint32_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -2680,10 +2680,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_Transform(/*in*/ Max
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MaxAbsScalarFeaturizer <uint64_t> */
+/* |  MaxAbsScalarFeaturizer <uint64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2691,12 +2691,12 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateEstimator(/*ou
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint64_EstimatorHandle*>(index);
 
 
     
@@ -2708,7 +2708,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateEstimator(/*ou
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2718,7 +2718,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_DestroyEstimator(/*i
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -2731,7 +2731,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_GetState(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_GetState(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2741,7 +2741,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_GetState(/*in*/ MaxA
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -2753,7 +2753,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_GetState(/*in*/ MaxA
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2763,7 +2763,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_IsTrainingComplete(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -2775,7 +2775,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_Fit(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_Fit(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2788,7 +2788,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_Fit(/*in*/ MaxAbsSca
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -2801,7 +2801,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_Fit(/*in*/ MaxAbsSca
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2816,7 +2816,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_FitBuffer(/*in*/ Max
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -2828,7 +2828,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_FitBuffer(/*in*/ Max
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2837,7 +2837,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_OnDataCompleted(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -2849,7 +2849,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2858,7 +2858,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CompleteTraining(/*i
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -2870,7 +2870,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2882,13 +2882,13 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateTransformerFro
 
 
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2898,7 +2898,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2911,10 +2911,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateTransformerFro
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2924,7 +2924,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2934,7 +2934,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_DestroyTransformer(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -2948,7 +2948,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2959,7 +2959,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateTransformerSav
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -2981,7 +2981,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_Transform(/*in*/ MaxAbsScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_Transform(/*in*/ MaxAbsScalarFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2994,7 +2994,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_Transform(/*in*/ Max
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::uint64_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -3012,10 +3012,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_Transform(/*in*/ Max
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MaxAbsScalarFeaturizer <double_t> */
+/* |  MaxAbsScalarFeaturizer <double> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3023,12 +3023,12 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateEstimator(/*ou
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>* pEstimator = new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 );
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_double_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MaxAbsScalarFeaturizer_double_EstimatorHandle*>(index);
 
 
     
@@ -3040,7 +3040,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateEstimator(/*ou
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3050,7 +3050,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_DestroyEstimator(/*i
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -3063,7 +3063,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_GetState(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_GetState(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3073,7 +3073,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_GetState(/*in*/ MaxA
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -3085,7 +3085,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_GetState(/*in*/ MaxA
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3095,7 +3095,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_IsTrainingComplete(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -3107,7 +3107,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_Fit(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_Fit(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3120,7 +3120,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_Fit(/*in*/ MaxAbsSca
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -3133,7 +3133,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_Fit(/*in*/ MaxAbsSca
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3148,7 +3148,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_FitBuffer(/*in*/ Max
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -3160,7 +3160,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_FitBuffer(/*in*/ Max
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3169,7 +3169,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_OnDataCompleted(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -3181,7 +3181,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3190,7 +3190,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CompleteTraining(/*i
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -3202,7 +3202,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3214,13 +3214,13 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateTransformerFro
 
 
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3230,7 +3230,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3243,10 +3243,10 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateTransformerFro
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MaxAbsScalarFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3256,7 +3256,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3266,7 +3266,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_DestroyTransformer(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -3280,7 +3280,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3291,7 +3291,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateTransformerSav
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -3313,7 +3313,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_Transform(/*in*/ MaxAbsScalarFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_Transform(/*in*/ MaxAbsScalarFeaturizer_double_TransformerHandle *pHandle, /*in*/ double input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3326,7 +3326,7 @@ FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_Transform(/*in*/ Max
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::MaxAbsScalarEstimator<std::double_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_MaxAbsScalarFeaturizer.h
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_MaxAbsScalarFeaturizer.h
@@ -9,253 +9,253 @@
 extern "C" {
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <int8_t> */
-struct MaxAbsScalarFeaturizer_int8_t_EstimatorHandle {};
-struct MaxAbsScalarFeaturizer_int8_t_TransformerHandle {};
+/* |  MaxAbsScalarFeaturizer <int8> */
+struct MaxAbsScalarFeaturizer_int8_EstimatorHandle {};
+struct MaxAbsScalarFeaturizer_int8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_GetState(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_Fit(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_GetState(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_Fit(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_t_Transform(/*in*/ MaxAbsScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int8_Transform(/*in*/ MaxAbsScalarFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <int16_t> */
-struct MaxAbsScalarFeaturizer_int16_t_EstimatorHandle {};
-struct MaxAbsScalarFeaturizer_int16_t_TransformerHandle {};
+/* |  MaxAbsScalarFeaturizer <int16> */
+struct MaxAbsScalarFeaturizer_int16_EstimatorHandle {};
+struct MaxAbsScalarFeaturizer_int16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_GetState(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_Fit(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_GetState(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_Fit(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_t_Transform(/*in*/ MaxAbsScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int16_Transform(/*in*/ MaxAbsScalarFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <uint8_t> */
-struct MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle {};
-struct MaxAbsScalarFeaturizer_uint8_t_TransformerHandle {};
+/* |  MaxAbsScalarFeaturizer <uint8> */
+struct MaxAbsScalarFeaturizer_uint8_EstimatorHandle {};
+struct MaxAbsScalarFeaturizer_uint8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_GetState(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_Fit(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_GetState(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_Fit(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_t_Transform(/*in*/ MaxAbsScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint8_Transform(/*in*/ MaxAbsScalarFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <uint16_t> */
-struct MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle {};
-struct MaxAbsScalarFeaturizer_uint16_t_TransformerHandle {};
+/* |  MaxAbsScalarFeaturizer <uint16> */
+struct MaxAbsScalarFeaturizer_uint16_EstimatorHandle {};
+struct MaxAbsScalarFeaturizer_uint16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_GetState(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_Fit(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_GetState(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_Fit(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_t_Transform(/*in*/ MaxAbsScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint16_Transform(/*in*/ MaxAbsScalarFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <float_t> */
-struct MaxAbsScalarFeaturizer_float_t_EstimatorHandle {};
-struct MaxAbsScalarFeaturizer_float_t_TransformerHandle {};
+/* |  MaxAbsScalarFeaturizer <float> */
+struct MaxAbsScalarFeaturizer_float_EstimatorHandle {};
+struct MaxAbsScalarFeaturizer_float_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_GetState(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_Fit(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_GetState(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_Fit(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_t_Transform(/*in*/ MaxAbsScalarFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_float_Transform(/*in*/ MaxAbsScalarFeaturizer_float_TransformerHandle *pHandle, /*in*/ float input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <int32_t> */
-struct MaxAbsScalarFeaturizer_int32_t_EstimatorHandle {};
-struct MaxAbsScalarFeaturizer_int32_t_TransformerHandle {};
+/* |  MaxAbsScalarFeaturizer <int32> */
+struct MaxAbsScalarFeaturizer_int32_EstimatorHandle {};
+struct MaxAbsScalarFeaturizer_int32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_GetState(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_Fit(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_GetState(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_Fit(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_t_Transform(/*in*/ MaxAbsScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int32_Transform(/*in*/ MaxAbsScalarFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <int64_t> */
-struct MaxAbsScalarFeaturizer_int64_t_EstimatorHandle {};
-struct MaxAbsScalarFeaturizer_int64_t_TransformerHandle {};
+/* |  MaxAbsScalarFeaturizer <int64> */
+struct MaxAbsScalarFeaturizer_int64_EstimatorHandle {};
+struct MaxAbsScalarFeaturizer_int64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_GetState(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_Fit(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_GetState(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_Fit(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_t_Transform(/*in*/ MaxAbsScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_int64_Transform(/*in*/ MaxAbsScalarFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <uint32_t> */
-struct MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle {};
-struct MaxAbsScalarFeaturizer_uint32_t_TransformerHandle {};
+/* |  MaxAbsScalarFeaturizer <uint32> */
+struct MaxAbsScalarFeaturizer_uint32_EstimatorHandle {};
+struct MaxAbsScalarFeaturizer_uint32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_GetState(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_Fit(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_GetState(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_Fit(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_t_Transform(/*in*/ MaxAbsScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint32_Transform(/*in*/ MaxAbsScalarFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <uint64_t> */
-struct MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle {};
-struct MaxAbsScalarFeaturizer_uint64_t_TransformerHandle {};
+/* |  MaxAbsScalarFeaturizer <uint64> */
+struct MaxAbsScalarFeaturizer_uint64_EstimatorHandle {};
+struct MaxAbsScalarFeaturizer_uint64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_GetState(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_Fit(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_GetState(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_Fit(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_t_Transform(/*in*/ MaxAbsScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_uint64_Transform(/*in*/ MaxAbsScalarFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <double_t> */
-struct MaxAbsScalarFeaturizer_double_t_EstimatorHandle {};
-struct MaxAbsScalarFeaturizer_double_t_TransformerHandle {};
+/* |  MaxAbsScalarFeaturizer <double> */
+struct MaxAbsScalarFeaturizer_double_EstimatorHandle {};
+struct MaxAbsScalarFeaturizer_double_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_CreateEstimator(/*out*/ MaxAbsScalarFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_DestroyEstimator(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_GetState(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_Fit(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_GetState(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_IsTrainingComplete(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_Fit(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_FitBuffer(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_OnDataCompleted(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_CompleteTraining(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_CreateTransformerFromEstimator(/*in*/ MaxAbsScalarFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ MaxAbsScalarFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MaxAbsScalarFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_DestroyTransformer(/*in*/ MaxAbsScalarFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_CreateTransformerSaveData(/*in*/ MaxAbsScalarFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_t_Transform(/*in*/ MaxAbsScalarFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MaxAbsScalarFeaturizer_double_Transform(/*in*/ MaxAbsScalarFeaturizer_double_TransformerHandle *pHandle, /*in*/ double input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 } // extern "C"

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_MinMaxScalarFeaturizer.cpp
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_MinMaxScalarFeaturizer.cpp
@@ -24,10 +24,10 @@ extern "C" {
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MinMaxScalarFeaturizer <int8_t> */
+/* |  MinMaxScalarFeaturizer <int8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -40,7 +40,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateEstimator(/*out*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_int8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_int8_EstimatorHandle*>(index);
 
 
     
@@ -52,7 +52,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateEstimator(/*out*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -75,7 +75,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_DestroyEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_GetState(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_GetState(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -97,7 +97,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_GetState(/*in*/ MinMax
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -119,7 +119,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_IsTrainingComplete(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_Fit(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_Fit(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -145,7 +145,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_Fit(/*in*/ MinMaxScala
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -172,7 +172,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_FitBuffer(/*in*/ MinMa
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -193,7 +193,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_OnDataCompleted(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -214,7 +214,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CompleteTraining(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -232,7 +232,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateTransformerFromE
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -242,7 +242,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateTransformerFromE
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -258,7 +258,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateTransformerFromS
         Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::int8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::int8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -268,7 +268,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateTransformerFromS
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -292,7 +292,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_DestroyTransformer(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -325,7 +325,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateTransformerSaveD
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_Transform(/*in*/ MinMaxScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_Transform(/*in*/ MinMaxScalarFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -356,10 +356,10 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_Transform(/*in*/ MinMa
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MinMaxScalarFeaturizer <int16_t> */
+/* |  MinMaxScalarFeaturizer <int16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -372,7 +372,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateEstimator(/*out
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_int16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_int16_EstimatorHandle*>(index);
 
 
     
@@ -384,7 +384,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateEstimator(/*out
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -407,7 +407,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_GetState(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_GetState(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -429,7 +429,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_GetState(/*in*/ MinMa
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -451,7 +451,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_Fit(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_Fit(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -477,7 +477,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_Fit(/*in*/ MinMaxScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -504,7 +504,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_FitBuffer(/*in*/ MinM
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -525,7 +525,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -546,7 +546,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -564,7 +564,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateTransformerFrom
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -574,7 +574,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -590,7 +590,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateTransformerFrom
         Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::int16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::int16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -600,7 +600,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -624,7 +624,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -657,7 +657,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_Transform(/*in*/ MinMaxScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_Transform(/*in*/ MinMaxScalarFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -688,10 +688,10 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_Transform(/*in*/ MinM
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MinMaxScalarFeaturizer <int32_t> */
+/* |  MinMaxScalarFeaturizer <int32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -704,7 +704,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateEstimator(/*out
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_int32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_int32_EstimatorHandle*>(index);
 
 
     
@@ -716,7 +716,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateEstimator(/*out
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -739,7 +739,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_GetState(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_GetState(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -761,7 +761,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_GetState(/*in*/ MinMa
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -783,7 +783,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_Fit(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_Fit(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -809,7 +809,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_Fit(/*in*/ MinMaxScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -836,7 +836,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_FitBuffer(/*in*/ MinM
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -857,7 +857,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -878,7 +878,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -896,7 +896,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateTransformerFrom
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -906,7 +906,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -922,7 +922,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateTransformerFrom
         Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::int32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::int32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -932,7 +932,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -956,7 +956,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -989,7 +989,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_Transform(/*in*/ MinMaxScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_Transform(/*in*/ MinMaxScalarFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1020,10 +1020,10 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_Transform(/*in*/ MinM
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MinMaxScalarFeaturizer <int64_t> */
+/* |  MinMaxScalarFeaturizer <int64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1036,7 +1036,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateEstimator(/*out
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_int64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_int64_EstimatorHandle*>(index);
 
 
     
@@ -1048,7 +1048,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateEstimator(/*out
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1071,7 +1071,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_GetState(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_GetState(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1093,7 +1093,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_GetState(/*in*/ MinMa
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1115,7 +1115,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_Fit(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_Fit(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1141,7 +1141,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_Fit(/*in*/ MinMaxScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1168,7 +1168,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_FitBuffer(/*in*/ MinM
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1189,7 +1189,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1210,7 +1210,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1228,7 +1228,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateTransformerFrom
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1238,7 +1238,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1254,7 +1254,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateTransformerFrom
         Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::int64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::int64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1264,7 +1264,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1288,7 +1288,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1321,7 +1321,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_Transform(/*in*/ MinMaxScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_Transform(/*in*/ MinMaxScalarFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1352,10 +1352,10 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_Transform(/*in*/ MinM
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MinMaxScalarFeaturizer <uint8_t> */
+/* |  MinMaxScalarFeaturizer <uint8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1368,7 +1368,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateEstimator(/*out
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint8_EstimatorHandle*>(index);
 
 
     
@@ -1380,7 +1380,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateEstimator(/*out
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1403,7 +1403,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_GetState(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_GetState(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1425,7 +1425,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_GetState(/*in*/ MinMa
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1447,7 +1447,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_Fit(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_Fit(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1473,7 +1473,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_Fit(/*in*/ MinMaxScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1500,7 +1500,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_FitBuffer(/*in*/ MinM
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1521,7 +1521,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1542,7 +1542,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1560,7 +1560,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateTransformerFrom
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1570,7 +1570,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1586,7 +1586,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateTransformerFrom
         Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::uint8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::uint8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1596,7 +1596,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1620,7 +1620,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1653,7 +1653,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_Transform(/*in*/ MinMaxScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_Transform(/*in*/ MinMaxScalarFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1684,10 +1684,10 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_Transform(/*in*/ MinM
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MinMaxScalarFeaturizer <uint16_t> */
+/* |  MinMaxScalarFeaturizer <uint16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1700,7 +1700,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateEstimator(/*ou
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint16_EstimatorHandle*>(index);
 
 
     
@@ -1712,7 +1712,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateEstimator(/*ou
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1735,7 +1735,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_GetState(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_GetState(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1757,7 +1757,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_GetState(/*in*/ MinM
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1779,7 +1779,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_Fit(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_Fit(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1805,7 +1805,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_Fit(/*in*/ MinMaxSca
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1832,7 +1832,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_FitBuffer(/*in*/ Min
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1853,7 +1853,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1874,7 +1874,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1892,7 +1892,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateTransformerFro
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -1902,7 +1902,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1918,7 +1918,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateTransformerFro
         Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::uint16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::uint16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -1928,7 +1928,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1952,7 +1952,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1985,7 +1985,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_Transform(/*in*/ MinMaxScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_Transform(/*in*/ MinMaxScalarFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2016,10 +2016,10 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_Transform(/*in*/ Min
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MinMaxScalarFeaturizer <uint32_t> */
+/* |  MinMaxScalarFeaturizer <uint32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2032,7 +2032,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateEstimator(/*ou
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint32_EstimatorHandle*>(index);
 
 
     
@@ -2044,7 +2044,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateEstimator(/*ou
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2067,7 +2067,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_GetState(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_GetState(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2089,7 +2089,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_GetState(/*in*/ MinM
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2111,7 +2111,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_Fit(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_Fit(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2137,7 +2137,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_Fit(/*in*/ MinMaxSca
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2164,7 +2164,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_FitBuffer(/*in*/ Min
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2185,7 +2185,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2206,7 +2206,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2224,7 +2224,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateTransformerFro
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2234,7 +2234,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2250,7 +2250,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateTransformerFro
         Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::uint32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::uint32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2260,7 +2260,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2284,7 +2284,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2317,7 +2317,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_Transform(/*in*/ MinMaxScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_Transform(/*in*/ MinMaxScalarFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2348,10 +2348,10 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_Transform(/*in*/ Min
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MinMaxScalarFeaturizer <uint64_t> */
+/* |  MinMaxScalarFeaturizer <uint64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2364,7 +2364,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateEstimator(/*ou
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint64_EstimatorHandle*>(index);
 
 
     
@@ -2376,7 +2376,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateEstimator(/*ou
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2399,7 +2399,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_GetState(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_GetState(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2421,7 +2421,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_GetState(/*in*/ MinM
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2443,7 +2443,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_Fit(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_Fit(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2469,7 +2469,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_Fit(/*in*/ MinMaxSca
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2496,7 +2496,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_FitBuffer(/*in*/ Min
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2517,7 +2517,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2538,7 +2538,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2556,7 +2556,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateTransformerFro
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2566,7 +2566,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2582,7 +2582,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateTransformerFro
         Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::uint64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::uint64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2592,7 +2592,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2616,7 +2616,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2649,7 +2649,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_Transform(/*in*/ MinMaxScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_Transform(/*in*/ MinMaxScalarFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2680,10 +2680,10 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_Transform(/*in*/ Min
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MinMaxScalarFeaturizer <float_t> */
+/* |  MinMaxScalarFeaturizer <float> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2696,7 +2696,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateEstimator(/*out
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_float_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_float_EstimatorHandle*>(index);
 
 
     
@@ -2708,7 +2708,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateEstimator(/*out
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2731,7 +2731,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_GetState(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_GetState(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2753,7 +2753,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_GetState(/*in*/ MinMa
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2775,7 +2775,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_Fit(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_Fit(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2801,7 +2801,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_Fit(/*in*/ MinMaxScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_FitBuffer(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2828,7 +2828,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_FitBuffer(/*in*/ MinM
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2849,7 +2849,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2870,7 +2870,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2888,7 +2888,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateTransformerFrom
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -2898,7 +2898,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2914,7 +2914,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateTransformerFrom
         Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::float_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -2924,7 +2924,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2948,7 +2948,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2981,7 +2981,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_Transform(/*in*/ MinMaxScalarFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_Transform(/*in*/ MinMaxScalarFeaturizer_float_TransformerHandle *pHandle, /*in*/ float input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3012,10 +3012,10 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_Transform(/*in*/ MinM
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MinMaxScalarFeaturizer <double_t> */
+/* |  MinMaxScalarFeaturizer <double> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3028,7 +3028,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateEstimator(/*ou
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_double_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MinMaxScalarFeaturizer_double_EstimatorHandle*>(index);
 
 
     
@@ -3040,7 +3040,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateEstimator(/*ou
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3063,7 +3063,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_GetState(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_GetState(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3085,7 +3085,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_GetState(/*in*/ MinM
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3107,7 +3107,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_Fit(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_Fit(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3133,7 +3133,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_Fit(/*in*/ MinMaxSca
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_FitBuffer(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3160,7 +3160,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_FitBuffer(/*in*/ Min
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3181,7 +3181,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3202,7 +3202,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3220,7 +3220,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateTransformerFro
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3230,7 +3230,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3246,7 +3246,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateTransformerFro
         Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MinMaxScalarEstimator<std::double_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MinMaxScalarFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3256,7 +3256,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3280,7 +3280,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3313,7 +3313,7 @@ FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_Transform(/*in*/ MinMaxScalarFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_Transform(/*in*/ MinMaxScalarFeaturizer_double_TransformerHandle *pHandle, /*in*/ double input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_MinMaxScalarFeaturizer.h
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_MinMaxScalarFeaturizer.h
@@ -9,253 +9,253 @@
 extern "C" {
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <int8_t> */
-struct MinMaxScalarFeaturizer_int8_t_EstimatorHandle {};
-struct MinMaxScalarFeaturizer_int8_t_TransformerHandle {};
+/* |  MinMaxScalarFeaturizer <int8> */
+struct MinMaxScalarFeaturizer_int8_EstimatorHandle {};
+struct MinMaxScalarFeaturizer_int8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_GetState(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_Fit(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_GetState(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_Fit(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_t_Transform(/*in*/ MinMaxScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int8_Transform(/*in*/ MinMaxScalarFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <int16_t> */
-struct MinMaxScalarFeaturizer_int16_t_EstimatorHandle {};
-struct MinMaxScalarFeaturizer_int16_t_TransformerHandle {};
+/* |  MinMaxScalarFeaturizer <int16> */
+struct MinMaxScalarFeaturizer_int16_EstimatorHandle {};
+struct MinMaxScalarFeaturizer_int16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_GetState(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_Fit(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_GetState(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_Fit(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_t_Transform(/*in*/ MinMaxScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int16_Transform(/*in*/ MinMaxScalarFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <int32_t> */
-struct MinMaxScalarFeaturizer_int32_t_EstimatorHandle {};
-struct MinMaxScalarFeaturizer_int32_t_TransformerHandle {};
+/* |  MinMaxScalarFeaturizer <int32> */
+struct MinMaxScalarFeaturizer_int32_EstimatorHandle {};
+struct MinMaxScalarFeaturizer_int32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_GetState(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_Fit(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_GetState(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_Fit(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_t_Transform(/*in*/ MinMaxScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int32_Transform(/*in*/ MinMaxScalarFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <int64_t> */
-struct MinMaxScalarFeaturizer_int64_t_EstimatorHandle {};
-struct MinMaxScalarFeaturizer_int64_t_TransformerHandle {};
+/* |  MinMaxScalarFeaturizer <int64> */
+struct MinMaxScalarFeaturizer_int64_EstimatorHandle {};
+struct MinMaxScalarFeaturizer_int64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_GetState(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_Fit(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_GetState(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_Fit(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_FitBuffer(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_t_Transform(/*in*/ MinMaxScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_int64_Transform(/*in*/ MinMaxScalarFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <uint8_t> */
-struct MinMaxScalarFeaturizer_uint8_t_EstimatorHandle {};
-struct MinMaxScalarFeaturizer_uint8_t_TransformerHandle {};
+/* |  MinMaxScalarFeaturizer <uint8> */
+struct MinMaxScalarFeaturizer_uint8_EstimatorHandle {};
+struct MinMaxScalarFeaturizer_uint8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_GetState(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_Fit(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_GetState(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_Fit(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_t_Transform(/*in*/ MinMaxScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint8_Transform(/*in*/ MinMaxScalarFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <uint16_t> */
-struct MinMaxScalarFeaturizer_uint16_t_EstimatorHandle {};
-struct MinMaxScalarFeaturizer_uint16_t_TransformerHandle {};
+/* |  MinMaxScalarFeaturizer <uint16> */
+struct MinMaxScalarFeaturizer_uint16_EstimatorHandle {};
+struct MinMaxScalarFeaturizer_uint16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_GetState(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_Fit(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_GetState(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_Fit(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_t_Transform(/*in*/ MinMaxScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint16_Transform(/*in*/ MinMaxScalarFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <uint32_t> */
-struct MinMaxScalarFeaturizer_uint32_t_EstimatorHandle {};
-struct MinMaxScalarFeaturizer_uint32_t_TransformerHandle {};
+/* |  MinMaxScalarFeaturizer <uint32> */
+struct MinMaxScalarFeaturizer_uint32_EstimatorHandle {};
+struct MinMaxScalarFeaturizer_uint32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_GetState(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_Fit(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_GetState(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_Fit(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_t_Transform(/*in*/ MinMaxScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint32_Transform(/*in*/ MinMaxScalarFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <uint64_t> */
-struct MinMaxScalarFeaturizer_uint64_t_EstimatorHandle {};
-struct MinMaxScalarFeaturizer_uint64_t_TransformerHandle {};
+/* |  MinMaxScalarFeaturizer <uint64> */
+struct MinMaxScalarFeaturizer_uint64_EstimatorHandle {};
+struct MinMaxScalarFeaturizer_uint64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_GetState(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_Fit(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_GetState(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_Fit(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_FitBuffer(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_t_Transform(/*in*/ MinMaxScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_uint64_Transform(/*in*/ MinMaxScalarFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <float_t> */
-struct MinMaxScalarFeaturizer_float_t_EstimatorHandle {};
-struct MinMaxScalarFeaturizer_float_t_TransformerHandle {};
+/* |  MinMaxScalarFeaturizer <float> */
+struct MinMaxScalarFeaturizer_float_EstimatorHandle {};
+struct MinMaxScalarFeaturizer_float_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_GetState(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_Fit(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_GetState(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_Fit(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_FitBuffer(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_t_Transform(/*in*/ MinMaxScalarFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_float_Transform(/*in*/ MinMaxScalarFeaturizer_float_TransformerHandle *pHandle, /*in*/ float input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <double_t> */
-struct MinMaxScalarFeaturizer_double_t_EstimatorHandle {};
-struct MinMaxScalarFeaturizer_double_t_TransformerHandle {};
+/* |  MinMaxScalarFeaturizer <double> */
+struct MinMaxScalarFeaturizer_double_EstimatorHandle {};
+struct MinMaxScalarFeaturizer_double_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_CreateEstimator(/*out*/ MinMaxScalarFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_DestroyEstimator(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_GetState(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_Fit(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_FitBuffer(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_GetState(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_IsTrainingComplete(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_Fit(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_FitBuffer(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_OnDataCompleted(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_CompleteTraining(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_CreateTransformerFromEstimator(/*in*/ MinMaxScalarFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ MinMaxScalarFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MinMaxScalarFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_DestroyTransformer(/*in*/ MinMaxScalarFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_CreateTransformerSaveData(/*in*/ MinMaxScalarFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_t_Transform(/*in*/ MinMaxScalarFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MinMaxScalarFeaturizer_double_Transform(/*in*/ MinMaxScalarFeaturizer_double_TransformerHandle *pHandle, /*in*/ double input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 } // extern "C"

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_MissingDummiesFeaturizer.cpp
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_MissingDummiesFeaturizer.cpp
@@ -24,10 +24,10 @@ extern "C" {
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MissingDummiesFeaturizer <int8_t> */
+/* |  MissingDummiesFeaturizer <int8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -40,7 +40,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateEstimator(/*ou
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_int8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_int8_EstimatorHandle*>(index);
 
 
     
@@ -52,7 +52,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateEstimator(/*ou
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -75,7 +75,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_GetState(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_GetState(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -97,7 +97,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_GetState(/*in*/ Miss
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -119,7 +119,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_Fit(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_Fit(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -145,7 +145,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_Fit(/*in*/ MissingDu
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_FitBuffer(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -187,7 +187,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_FitBuffer(/*in*/ Mis
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -208,7 +208,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -229,7 +229,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -247,7 +247,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateTransformerFro
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -257,7 +257,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -273,7 +273,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateTransformerFro
         Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::int8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::int8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -283,7 +283,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -307,7 +307,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -340,7 +340,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_Transform(/*in*/ MissingDummiesFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_Transform(/*in*/ MissingDummiesFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -371,10 +371,10 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_Transform(/*in*/ Mis
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MissingDummiesFeaturizer <int16_t> */
+/* |  MissingDummiesFeaturizer <int16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -387,7 +387,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateEstimator(/*o
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_int16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_int16_EstimatorHandle*>(index);
 
 
     
@@ -399,7 +399,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateEstimator(/*o
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -422,7 +422,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_DestroyEstimator(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_GetState(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_GetState(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -444,7 +444,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_GetState(/*in*/ Mis
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -466,7 +466,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_IsTrainingComplete(
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_Fit(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_Fit(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -492,7 +492,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_Fit(/*in*/ MissingD
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_FitBuffer(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -534,7 +534,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_FitBuffer(/*in*/ Mi
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -555,7 +555,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_OnDataCompleted(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -576,7 +576,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CompleteTraining(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -594,7 +594,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateTransformerFr
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -604,7 +604,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -620,7 +620,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateTransformerFr
         Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::int16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::int16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -630,7 +630,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -654,7 +654,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_DestroyTransformer(
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -687,7 +687,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateTransformerSa
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_Transform(/*in*/ MissingDummiesFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_Transform(/*in*/ MissingDummiesFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -718,10 +718,10 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_Transform(/*in*/ Mi
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MissingDummiesFeaturizer <int32_t> */
+/* |  MissingDummiesFeaturizer <int32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -734,7 +734,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateEstimator(/*o
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_int32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_int32_EstimatorHandle*>(index);
 
 
     
@@ -746,7 +746,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateEstimator(/*o
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -769,7 +769,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_DestroyEstimator(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_GetState(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_GetState(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -791,7 +791,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_GetState(/*in*/ Mis
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -813,7 +813,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_IsTrainingComplete(
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_Fit(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_Fit(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -839,7 +839,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_Fit(/*in*/ MissingD
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_FitBuffer(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -881,7 +881,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_FitBuffer(/*in*/ Mi
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -902,7 +902,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_OnDataCompleted(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -923,7 +923,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CompleteTraining(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -941,7 +941,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateTransformerFr
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -951,7 +951,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -967,7 +967,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateTransformerFr
         Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::int32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::int32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -977,7 +977,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1001,7 +1001,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_DestroyTransformer(
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1034,7 +1034,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateTransformerSa
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_Transform(/*in*/ MissingDummiesFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_Transform(/*in*/ MissingDummiesFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1065,10 +1065,10 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_Transform(/*in*/ Mi
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MissingDummiesFeaturizer <int64_t> */
+/* |  MissingDummiesFeaturizer <int64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1081,7 +1081,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateEstimator(/*o
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_int64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_int64_EstimatorHandle*>(index);
 
 
     
@@ -1093,7 +1093,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateEstimator(/*o
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1116,7 +1116,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_DestroyEstimator(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_GetState(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_GetState(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1138,7 +1138,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_GetState(/*in*/ Mis
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1160,7 +1160,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_IsTrainingComplete(
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_Fit(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_Fit(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1186,7 +1186,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_Fit(/*in*/ MissingD
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_FitBuffer(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1228,7 +1228,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_FitBuffer(/*in*/ Mi
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1249,7 +1249,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_OnDataCompleted(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1270,7 +1270,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CompleteTraining(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1288,7 +1288,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateTransformerFr
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1298,7 +1298,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1314,7 +1314,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateTransformerFr
         Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::int64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::int64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1324,7 +1324,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1348,7 +1348,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_DestroyTransformer(
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1381,7 +1381,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateTransformerSa
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_Transform(/*in*/ MissingDummiesFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_Transform(/*in*/ MissingDummiesFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1412,10 +1412,10 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_Transform(/*in*/ Mi
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MissingDummiesFeaturizer <uint8_t> */
+/* |  MissingDummiesFeaturizer <uint8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1428,7 +1428,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateEstimator(/*o
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_uint8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_uint8_EstimatorHandle*>(index);
 
 
     
@@ -1440,7 +1440,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateEstimator(/*o
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1463,7 +1463,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_DestroyEstimator(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_GetState(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_GetState(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1485,7 +1485,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_GetState(/*in*/ Mis
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1507,7 +1507,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_IsTrainingComplete(
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_Fit(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_Fit(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1533,7 +1533,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_Fit(/*in*/ MissingD
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1575,7 +1575,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_FitBuffer(/*in*/ Mi
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1596,7 +1596,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_OnDataCompleted(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1617,7 +1617,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CompleteTraining(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1635,7 +1635,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateTransformerFr
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1645,7 +1645,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1661,7 +1661,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateTransformerFr
         Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::uint8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::uint8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1671,7 +1671,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1695,7 +1695,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_DestroyTransformer(
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1728,7 +1728,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateTransformerSa
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_Transform(/*in*/ MissingDummiesFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_Transform(/*in*/ MissingDummiesFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1759,10 +1759,10 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_Transform(/*in*/ Mi
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MissingDummiesFeaturizer <uint16_t> */
+/* |  MissingDummiesFeaturizer <uint16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1775,7 +1775,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateEstimator(/*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_uint16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_uint16_EstimatorHandle*>(index);
 
 
     
@@ -1787,7 +1787,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateEstimator(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1810,7 +1810,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_DestroyEstimator(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_GetState(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_GetState(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1832,7 +1832,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_GetState(/*in*/ Mi
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1854,7 +1854,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_IsTrainingComplete
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_Fit(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_Fit(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1880,7 +1880,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_Fit(/*in*/ Missing
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1922,7 +1922,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_FitBuffer(/*in*/ M
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1943,7 +1943,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_OnDataCompleted(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1964,7 +1964,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CompleteTraining(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1982,7 +1982,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateTransformerF
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -1992,7 +1992,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateTransformerF
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2008,7 +2008,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateTransformerF
         Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::uint16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::uint16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -2018,7 +2018,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateTransformerF
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2042,7 +2042,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_DestroyTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2075,7 +2075,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateTransformerS
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_Transform(/*in*/ MissingDummiesFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_Transform(/*in*/ MissingDummiesFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2106,10 +2106,10 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_Transform(/*in*/ M
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MissingDummiesFeaturizer <uint32_t> */
+/* |  MissingDummiesFeaturizer <uint32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2122,7 +2122,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateEstimator(/*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_uint32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_uint32_EstimatorHandle*>(index);
 
 
     
@@ -2134,7 +2134,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateEstimator(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2157,7 +2157,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_DestroyEstimator(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_GetState(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_GetState(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2179,7 +2179,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_GetState(/*in*/ Mi
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2201,7 +2201,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_IsTrainingComplete
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_Fit(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_Fit(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2227,7 +2227,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_Fit(/*in*/ Missing
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2269,7 +2269,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_FitBuffer(/*in*/ M
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2290,7 +2290,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_OnDataCompleted(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2311,7 +2311,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CompleteTraining(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2329,7 +2329,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateTransformerF
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2339,7 +2339,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateTransformerF
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2355,7 +2355,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateTransformerF
         Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::uint32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::uint32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2365,7 +2365,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateTransformerF
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2389,7 +2389,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_DestroyTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2422,7 +2422,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateTransformerS
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_Transform(/*in*/ MissingDummiesFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_Transform(/*in*/ MissingDummiesFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2453,10 +2453,10 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_Transform(/*in*/ M
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MissingDummiesFeaturizer <uint64_t> */
+/* |  MissingDummiesFeaturizer <uint64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2469,7 +2469,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateEstimator(/*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_uint64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_uint64_EstimatorHandle*>(index);
 
 
     
@@ -2481,7 +2481,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateEstimator(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2504,7 +2504,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_DestroyEstimator(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_GetState(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_GetState(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2526,7 +2526,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_GetState(/*in*/ Mi
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2548,7 +2548,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_IsTrainingComplete
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_Fit(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_Fit(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2574,7 +2574,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_Fit(/*in*/ Missing
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2616,7 +2616,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_FitBuffer(/*in*/ M
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2637,7 +2637,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_OnDataCompleted(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2658,7 +2658,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CompleteTraining(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2676,7 +2676,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateTransformerF
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2686,7 +2686,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateTransformerF
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2702,7 +2702,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateTransformerF
         Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::uint64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::uint64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2712,7 +2712,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateTransformerF
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2736,7 +2736,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_DestroyTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2769,7 +2769,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateTransformerS
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_Transform(/*in*/ MissingDummiesFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_Transform(/*in*/ MissingDummiesFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2800,10 +2800,10 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_Transform(/*in*/ M
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MissingDummiesFeaturizer <float_t> */
+/* |  MissingDummiesFeaturizer <float> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_CreateEstimator(/*out*/ MissingDummiesFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2816,7 +2816,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateEstimator(/*o
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_float_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_float_EstimatorHandle*>(index);
 
 
     
@@ -2828,7 +2828,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateEstimator(/*o
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2851,7 +2851,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_DestroyEstimator(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_GetState(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_GetState(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2873,7 +2873,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_GetState(/*in*/ Mis
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2895,7 +2895,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_IsTrainingComplete(
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_Fit(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_Fit(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2921,7 +2921,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_Fit(/*in*/ MissingD
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_FitBuffer(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2963,7 +2963,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_FitBuffer(/*in*/ Mi
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2984,7 +2984,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_OnDataCompleted(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_CompleteTraining(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3005,7 +3005,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CompleteTraining(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3023,7 +3023,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateTransformerFr
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -3033,7 +3033,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3049,7 +3049,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateTransformerFr
         Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::float_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -3059,7 +3059,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3083,7 +3083,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_DestroyTransformer(
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3116,7 +3116,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateTransformerSa
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_Transform(/*in*/ MissingDummiesFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_Transform(/*in*/ MissingDummiesFeaturizer_float_TransformerHandle *pHandle, /*in*/ float const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3147,10 +3147,10 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_Transform(/*in*/ Mi
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  MissingDummiesFeaturizer <double_t> */
+/* |  MissingDummiesFeaturizer <double> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_CreateEstimator(/*out*/ MissingDummiesFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3163,7 +3163,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateEstimator(/*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_double_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<MissingDummiesFeaturizer_double_EstimatorHandle*>(index);
 
 
     
@@ -3175,7 +3175,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateEstimator(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3198,7 +3198,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_DestroyEstimator(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_GetState(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_GetState(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3220,7 +3220,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_GetState(/*in*/ Mi
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3242,7 +3242,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_IsTrainingComplete
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_Fit(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_Fit(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3268,7 +3268,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_Fit(/*in*/ Missing
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_FitBuffer(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3310,7 +3310,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_FitBuffer(/*in*/ M
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3331,7 +3331,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_OnDataCompleted(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_CompleteTraining(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3352,7 +3352,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CompleteTraining(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3370,7 +3370,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateTransformerF
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3380,7 +3380,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateTransformerF
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3396,7 +3396,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateTransformerF
         Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::MissingDummiesEstimator<std::double_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<MissingDummiesFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3406,7 +3406,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateTransformerF
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3430,7 +3430,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_DestroyTransformer
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3463,7 +3463,7 @@ FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateTransformerS
     }
 }
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_Transform(/*in*/ MissingDummiesFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_Transform(/*in*/ MissingDummiesFeaturizer_double_TransformerHandle *pHandle, /*in*/ double const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_MissingDummiesFeaturizer.h
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_MissingDummiesFeaturizer.h
@@ -9,254 +9,254 @@
 extern "C" {
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <int8_t> */
-struct MissingDummiesFeaturizer_int8_t_EstimatorHandle {};
-struct MissingDummiesFeaturizer_int8_t_TransformerHandle {};
+/* |  MissingDummiesFeaturizer <int8> */
+struct MissingDummiesFeaturizer_int8_EstimatorHandle {};
+struct MissingDummiesFeaturizer_int8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_GetState(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_Fit(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_GetState(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_Fit(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_FitBuffer(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_t_Transform(/*in*/ MissingDummiesFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int8_Transform(/*in*/ MissingDummiesFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <int16_t> */
-struct MissingDummiesFeaturizer_int16_t_EstimatorHandle {};
-struct MissingDummiesFeaturizer_int16_t_TransformerHandle {};
+/* |  MissingDummiesFeaturizer <int16> */
+struct MissingDummiesFeaturizer_int16_EstimatorHandle {};
+struct MissingDummiesFeaturizer_int16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_GetState(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_Fit(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_GetState(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_Fit(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_FitBuffer(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_t_Transform(/*in*/ MissingDummiesFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int16_Transform(/*in*/ MissingDummiesFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <int32_t> */
-struct MissingDummiesFeaturizer_int32_t_EstimatorHandle {};
-struct MissingDummiesFeaturizer_int32_t_TransformerHandle {};
+/* |  MissingDummiesFeaturizer <int32> */
+struct MissingDummiesFeaturizer_int32_EstimatorHandle {};
+struct MissingDummiesFeaturizer_int32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_GetState(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_Fit(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_GetState(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_Fit(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_FitBuffer(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_t_Transform(/*in*/ MissingDummiesFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int32_Transform(/*in*/ MissingDummiesFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <int64_t> */
-struct MissingDummiesFeaturizer_int64_t_EstimatorHandle {};
-struct MissingDummiesFeaturizer_int64_t_TransformerHandle {};
+/* |  MissingDummiesFeaturizer <int64> */
+struct MissingDummiesFeaturizer_int64_EstimatorHandle {};
+struct MissingDummiesFeaturizer_int64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_CreateEstimator(/*out*/ MissingDummiesFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_GetState(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_Fit(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_GetState(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_Fit(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_FitBuffer(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_CompleteTraining(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_t_Transform(/*in*/ MissingDummiesFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_int64_Transform(/*in*/ MissingDummiesFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <uint8_t> */
-struct MissingDummiesFeaturizer_uint8_t_EstimatorHandle {};
-struct MissingDummiesFeaturizer_uint8_t_TransformerHandle {};
+/* |  MissingDummiesFeaturizer <uint8> */
+struct MissingDummiesFeaturizer_uint8_EstimatorHandle {};
+struct MissingDummiesFeaturizer_uint8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_GetState(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_Fit(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_GetState(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_Fit(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_t_Transform(/*in*/ MissingDummiesFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint8_Transform(/*in*/ MissingDummiesFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <uint16_t> */
-struct MissingDummiesFeaturizer_uint16_t_EstimatorHandle {};
-struct MissingDummiesFeaturizer_uint16_t_TransformerHandle {};
+/* |  MissingDummiesFeaturizer <uint16> */
+struct MissingDummiesFeaturizer_uint16_EstimatorHandle {};
+struct MissingDummiesFeaturizer_uint16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_GetState(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_Fit(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_GetState(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_Fit(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_t_Transform(/*in*/ MissingDummiesFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint16_Transform(/*in*/ MissingDummiesFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <uint32_t> */
-struct MissingDummiesFeaturizer_uint32_t_EstimatorHandle {};
-struct MissingDummiesFeaturizer_uint32_t_TransformerHandle {};
+/* |  MissingDummiesFeaturizer <uint32> */
+struct MissingDummiesFeaturizer_uint32_EstimatorHandle {};
+struct MissingDummiesFeaturizer_uint32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_GetState(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_Fit(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_GetState(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_Fit(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_t_Transform(/*in*/ MissingDummiesFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint32_Transform(/*in*/ MissingDummiesFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <uint64_t> */
-struct MissingDummiesFeaturizer_uint64_t_EstimatorHandle {};
-struct MissingDummiesFeaturizer_uint64_t_TransformerHandle {};
+/* |  MissingDummiesFeaturizer <uint64> */
+struct MissingDummiesFeaturizer_uint64_EstimatorHandle {};
+struct MissingDummiesFeaturizer_uint64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_CreateEstimator(/*out*/ MissingDummiesFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_GetState(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_Fit(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_GetState(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_Fit(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_FitBuffer(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_CompleteTraining(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_t_Transform(/*in*/ MissingDummiesFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_uint64_Transform(/*in*/ MissingDummiesFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <float_t> */
-struct MissingDummiesFeaturizer_float_t_EstimatorHandle {};
-struct MissingDummiesFeaturizer_float_t_TransformerHandle {};
+/* |  MissingDummiesFeaturizer <float> */
+struct MissingDummiesFeaturizer_float_EstimatorHandle {};
+struct MissingDummiesFeaturizer_float_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_CreateEstimator(/*out*/ MissingDummiesFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_GetState(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_Fit(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_GetState(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_Fit(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_FitBuffer(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_CompleteTraining(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_t_Transform(/*in*/ MissingDummiesFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_float_Transform(/*in*/ MissingDummiesFeaturizer_float_TransformerHandle *pHandle, /*in*/ float const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <double_t> */
-struct MissingDummiesFeaturizer_double_t_EstimatorHandle {};
-struct MissingDummiesFeaturizer_double_t_TransformerHandle {};
+/* |  MissingDummiesFeaturizer <double> */
+struct MissingDummiesFeaturizer_double_EstimatorHandle {};
+struct MissingDummiesFeaturizer_double_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateEstimator(/*out*/ MissingDummiesFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_CreateEstimator(/*out*/ MissingDummiesFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_DestroyEstimator(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_GetState(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_Fit(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_FitBuffer(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CompleteTraining(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_GetState(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_IsTrainingComplete(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_Fit(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_FitBuffer(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_OnDataCompleted(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_CompleteTraining(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_CreateTransformerFromEstimator(/*in*/ MissingDummiesFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ MissingDummiesFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ MissingDummiesFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_DestroyTransformer(/*in*/ MissingDummiesFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_CreateTransformerSaveData(/*in*/ MissingDummiesFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_t_Transform(/*in*/ MissingDummiesFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool MissingDummiesFeaturizer_double_Transform(/*in*/ MissingDummiesFeaturizer_double_TransformerHandle *pHandle, /*in*/ double const * input, /*out*/ int8_t * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
 /* |  MissingDummiesFeaturizer <bool> */

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_OneHotEncoderFeaturizer.cpp
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_OneHotEncoderFeaturizer.cpp
@@ -24,10 +24,10 @@ extern "C" {
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  OneHotEncoderFeaturizer <int8_t> */
+/* |  OneHotEncoderFeaturizer <int8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -40,7 +40,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateEstimator(/*in*
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_int8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_int8_EstimatorHandle*>(index);
 
 
     
@@ -52,7 +52,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -75,7 +75,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_GetState(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_GetState(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -97,7 +97,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_GetState(/*in*/ OneHo
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -119,7 +119,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_Fit(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_Fit(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -145,7 +145,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_Fit(/*in*/ OneHotEnco
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -172,7 +172,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_FitBuffer(/*in*/ OneH
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -193,7 +193,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -214,7 +214,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -232,7 +232,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateTransformerFrom
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -242,7 +242,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -258,7 +258,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateTransformerFrom
         Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::int8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::int8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -268,7 +268,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -292,7 +292,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -325,7 +325,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_Transform(/*in*/ OneHotEncoderFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_Transform(/*in*/ OneHotEncoderFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -356,7 +356,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_Transform(/*in*/ OneH
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -377,10 +377,10 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_DestroyTransformedDat
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  OneHotEncoderFeaturizer <int16_t> */
+/* |  OneHotEncoderFeaturizer <int16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -393,7 +393,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateEstimator(/*in
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_int16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_int16_EstimatorHandle*>(index);
 
 
     
@@ -405,7 +405,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -428,7 +428,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_GetState(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_GetState(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -450,7 +450,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_GetState(/*in*/ OneH
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -472,7 +472,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_Fit(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_Fit(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -498,7 +498,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_Fit(/*in*/ OneHotEnc
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -525,7 +525,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_FitBuffer(/*in*/ One
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -546,7 +546,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -567,7 +567,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -585,7 +585,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateTransformerFro
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -595,7 +595,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -611,7 +611,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateTransformerFro
         Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::int16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::int16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -621,7 +621,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -645,7 +645,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -678,7 +678,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_Transform(/*in*/ OneHotEncoderFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_Transform(/*in*/ OneHotEncoderFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -709,7 +709,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_Transform(/*in*/ One
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -730,10 +730,10 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_DestroyTransformedDa
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  OneHotEncoderFeaturizer <int32_t> */
+/* |  OneHotEncoderFeaturizer <int32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -746,7 +746,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateEstimator(/*in
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_int32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_int32_EstimatorHandle*>(index);
 
 
     
@@ -758,7 +758,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -781,7 +781,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_GetState(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_GetState(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -803,7 +803,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_GetState(/*in*/ OneH
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -825,7 +825,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_Fit(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_Fit(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -851,7 +851,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_Fit(/*in*/ OneHotEnc
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -878,7 +878,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_FitBuffer(/*in*/ One
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -899,7 +899,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -920,7 +920,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -938,7 +938,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateTransformerFro
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -948,7 +948,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -964,7 +964,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateTransformerFro
         Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::int32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::int32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -974,7 +974,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -998,7 +998,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1031,7 +1031,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_Transform(/*in*/ OneHotEncoderFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_Transform(/*in*/ OneHotEncoderFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1062,7 +1062,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_Transform(/*in*/ One
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1083,10 +1083,10 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_DestroyTransformedDa
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  OneHotEncoderFeaturizer <int64_t> */
+/* |  OneHotEncoderFeaturizer <int64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1099,7 +1099,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateEstimator(/*in
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_int64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_int64_EstimatorHandle*>(index);
 
 
     
@@ -1111,7 +1111,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1134,7 +1134,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_GetState(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_GetState(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1156,7 +1156,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_GetState(/*in*/ OneH
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1178,7 +1178,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_Fit(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_Fit(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1204,7 +1204,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_Fit(/*in*/ OneHotEnc
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1231,7 +1231,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_FitBuffer(/*in*/ One
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1252,7 +1252,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1273,7 +1273,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1291,7 +1291,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateTransformerFro
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1301,7 +1301,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1317,7 +1317,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateTransformerFro
         Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::int64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::int64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1327,7 +1327,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1351,7 +1351,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1384,7 +1384,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_Transform(/*in*/ OneHotEncoderFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_Transform(/*in*/ OneHotEncoderFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1415,7 +1415,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_Transform(/*in*/ One
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1436,10 +1436,10 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_DestroyTransformedDa
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  OneHotEncoderFeaturizer <uint8_t> */
+/* |  OneHotEncoderFeaturizer <uint8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1452,7 +1452,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateEstimator(/*in
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint8_EstimatorHandle*>(index);
 
 
     
@@ -1464,7 +1464,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1487,7 +1487,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_GetState(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_GetState(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1509,7 +1509,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_GetState(/*in*/ OneH
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1531,7 +1531,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_Fit(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_Fit(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1557,7 +1557,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_Fit(/*in*/ OneHotEnc
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1584,7 +1584,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_FitBuffer(/*in*/ One
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1605,7 +1605,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1626,7 +1626,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1644,7 +1644,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateTransformerFro
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1654,7 +1654,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1670,7 +1670,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateTransformerFro
         Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::uint8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::uint8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1680,7 +1680,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1704,7 +1704,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1737,7 +1737,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_Transform(/*in*/ OneHotEncoderFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_Transform(/*in*/ OneHotEncoderFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1768,7 +1768,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_Transform(/*in*/ One
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1789,10 +1789,10 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_DestroyTransformedDa
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  OneHotEncoderFeaturizer <uint16_t> */
+/* |  OneHotEncoderFeaturizer <uint16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1805,7 +1805,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateEstimator(/*i
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint16_EstimatorHandle*>(index);
 
 
     
@@ -1817,7 +1817,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1840,7 +1840,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_DestroyEstimator(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_GetState(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_GetState(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1862,7 +1862,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_GetState(/*in*/ One
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1884,7 +1884,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_IsTrainingComplete(
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_Fit(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_Fit(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1910,7 +1910,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_Fit(/*in*/ OneHotEn
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1937,7 +1937,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_FitBuffer(/*in*/ On
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1958,7 +1958,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_OnDataCompleted(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1979,7 +1979,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CompleteTraining(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1997,7 +1997,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateTransformerFr
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -2007,7 +2007,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2023,7 +2023,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateTransformerFr
         Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::uint16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::uint16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -2033,7 +2033,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2057,7 +2057,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_DestroyTransformer(
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2090,7 +2090,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateTransformerSa
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_Transform(/*in*/ OneHotEncoderFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_Transform(/*in*/ OneHotEncoderFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2121,7 +2121,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_Transform(/*in*/ On
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2142,10 +2142,10 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_DestroyTransformedD
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  OneHotEncoderFeaturizer <uint32_t> */
+/* |  OneHotEncoderFeaturizer <uint32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2158,7 +2158,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateEstimator(/*i
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint32_EstimatorHandle*>(index);
 
 
     
@@ -2170,7 +2170,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2193,7 +2193,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_DestroyEstimator(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_GetState(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_GetState(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2215,7 +2215,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_GetState(/*in*/ One
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2237,7 +2237,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_IsTrainingComplete(
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_Fit(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_Fit(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2263,7 +2263,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_Fit(/*in*/ OneHotEn
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2290,7 +2290,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_FitBuffer(/*in*/ On
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2311,7 +2311,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_OnDataCompleted(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2332,7 +2332,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CompleteTraining(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2350,7 +2350,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateTransformerFr
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2360,7 +2360,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2376,7 +2376,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateTransformerFr
         Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::uint32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::uint32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2386,7 +2386,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2410,7 +2410,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_DestroyTransformer(
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2443,7 +2443,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateTransformerSa
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_Transform(/*in*/ OneHotEncoderFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_Transform(/*in*/ OneHotEncoderFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2474,7 +2474,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_Transform(/*in*/ On
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2495,10 +2495,10 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_DestroyTransformedD
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  OneHotEncoderFeaturizer <uint64_t> */
+/* |  OneHotEncoderFeaturizer <uint64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2511,7 +2511,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateEstimator(/*i
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint64_EstimatorHandle*>(index);
 
 
     
@@ -2523,7 +2523,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2546,7 +2546,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_DestroyEstimator(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_GetState(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_GetState(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2568,7 +2568,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_GetState(/*in*/ One
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2590,7 +2590,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_IsTrainingComplete(
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_Fit(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_Fit(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2616,7 +2616,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_Fit(/*in*/ OneHotEn
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2643,7 +2643,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_FitBuffer(/*in*/ On
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2664,7 +2664,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_OnDataCompleted(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2685,7 +2685,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CompleteTraining(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2703,7 +2703,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateTransformerFr
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2713,7 +2713,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2729,7 +2729,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateTransformerFr
         Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::uint64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::uint64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2739,7 +2739,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2763,7 +2763,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_DestroyTransformer(
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2796,7 +2796,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateTransformerSa
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_Transform(/*in*/ OneHotEncoderFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_Transform(/*in*/ OneHotEncoderFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2827,7 +2827,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_Transform(/*in*/ On
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2848,10 +2848,10 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_DestroyTransformedD
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  OneHotEncoderFeaturizer <float_t> */
+/* |  OneHotEncoderFeaturizer <float> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2864,7 +2864,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateEstimator(/*in
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_float_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_float_EstimatorHandle*>(index);
 
 
     
@@ -2876,7 +2876,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2899,7 +2899,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_GetState(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_GetState(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2921,7 +2921,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_GetState(/*in*/ OneH
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2943,7 +2943,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_Fit(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_Fit(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2969,7 +2969,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_Fit(/*in*/ OneHotEnc
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_FitBuffer(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2996,7 +2996,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_FitBuffer(/*in*/ One
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3017,7 +3017,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3038,7 +3038,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3056,7 +3056,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateTransformerFro
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -3066,7 +3066,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3082,7 +3082,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateTransformerFro
         Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::float_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -3092,7 +3092,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3116,7 +3116,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3149,7 +3149,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_Transform(/*in*/ OneHotEncoderFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_Transform(/*in*/ OneHotEncoderFeaturizer_float_TransformerHandle *pHandle, /*in*/ float input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3180,7 +3180,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_Transform(/*in*/ One
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3201,10 +3201,10 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_DestroyTransformedDa
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  OneHotEncoderFeaturizer <double_t> */
+/* |  OneHotEncoderFeaturizer <double> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors, /*out*/ OneHotEncoderFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3217,7 +3217,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateEstimator(/*i
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_double_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<OneHotEncoderFeaturizer_double_EstimatorHandle*>(index);
 
 
     
@@ -3229,7 +3229,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3252,7 +3252,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_DestroyEstimator(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_GetState(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_GetState(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3274,7 +3274,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_GetState(/*in*/ One
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3296,7 +3296,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_IsTrainingComplete(
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_Fit(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_Fit(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3322,7 +3322,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_Fit(/*in*/ OneHotEn
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_FitBuffer(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3349,7 +3349,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_FitBuffer(/*in*/ On
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3370,7 +3370,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_OnDataCompleted(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3391,7 +3391,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CompleteTraining(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3409,7 +3409,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateTransformerFr
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3419,7 +3419,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3435,7 +3435,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateTransformerFr
         Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::OneHotEncoderEstimator<std::double_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<OneHotEncoderFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3445,7 +3445,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateTransformerFr
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3469,7 +3469,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_DestroyTransformer(
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3502,7 +3502,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateTransformerSa
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_Transform(/*in*/ OneHotEncoderFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_Transform(/*in*/ OneHotEncoderFeaturizer_double_TransformerHandle *pHandle, /*in*/ double input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3533,7 +3533,7 @@ FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_Transform(/*in*/ On
     }
 }
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_OneHotEncoderFeaturizer.h
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_OneHotEncoderFeaturizer.h
@@ -19,264 +19,264 @@ FEATURIZER_LIBRARY_API_PACK_SUFFIX
 
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <int8_t> */
-struct OneHotEncoderFeaturizer_int8_t_EstimatorHandle {};
-struct OneHotEncoderFeaturizer_int8_t_TransformerHandle {};
+/* |  OneHotEncoderFeaturizer <int8> */
+struct OneHotEncoderFeaturizer_int8_EstimatorHandle {};
+struct OneHotEncoderFeaturizer_int8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_GetState(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_Fit(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_GetState(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_Fit(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_Transform(/*in*/ OneHotEncoderFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_Transform(/*in*/ OneHotEncoderFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int8_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <int16_t> */
-struct OneHotEncoderFeaturizer_int16_t_EstimatorHandle {};
-struct OneHotEncoderFeaturizer_int16_t_TransformerHandle {};
+/* |  OneHotEncoderFeaturizer <int16> */
+struct OneHotEncoderFeaturizer_int16_EstimatorHandle {};
+struct OneHotEncoderFeaturizer_int16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_GetState(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_Fit(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_GetState(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_Fit(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_Transform(/*in*/ OneHotEncoderFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_Transform(/*in*/ OneHotEncoderFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int16_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <int32_t> */
-struct OneHotEncoderFeaturizer_int32_t_EstimatorHandle {};
-struct OneHotEncoderFeaturizer_int32_t_TransformerHandle {};
+/* |  OneHotEncoderFeaturizer <int32> */
+struct OneHotEncoderFeaturizer_int32_EstimatorHandle {};
+struct OneHotEncoderFeaturizer_int32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_GetState(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_Fit(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_GetState(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_Fit(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_Transform(/*in*/ OneHotEncoderFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_Transform(/*in*/ OneHotEncoderFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int32_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <int64_t> */
-struct OneHotEncoderFeaturizer_int64_t_EstimatorHandle {};
-struct OneHotEncoderFeaturizer_int64_t_TransformerHandle {};
+/* |  OneHotEncoderFeaturizer <int64> */
+struct OneHotEncoderFeaturizer_int64_EstimatorHandle {};
+struct OneHotEncoderFeaturizer_int64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_GetState(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_Fit(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_GetState(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_Fit(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_FitBuffer(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_Transform(/*in*/ OneHotEncoderFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_Transform(/*in*/ OneHotEncoderFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_int64_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <uint8_t> */
-struct OneHotEncoderFeaturizer_uint8_t_EstimatorHandle {};
-struct OneHotEncoderFeaturizer_uint8_t_TransformerHandle {};
+/* |  OneHotEncoderFeaturizer <uint8> */
+struct OneHotEncoderFeaturizer_uint8_EstimatorHandle {};
+struct OneHotEncoderFeaturizer_uint8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_GetState(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_Fit(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_GetState(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_Fit(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_Transform(/*in*/ OneHotEncoderFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_Transform(/*in*/ OneHotEncoderFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint8_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <uint16_t> */
-struct OneHotEncoderFeaturizer_uint16_t_EstimatorHandle {};
-struct OneHotEncoderFeaturizer_uint16_t_TransformerHandle {};
+/* |  OneHotEncoderFeaturizer <uint16> */
+struct OneHotEncoderFeaturizer_uint16_EstimatorHandle {};
+struct OneHotEncoderFeaturizer_uint16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_GetState(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_Fit(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_GetState(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_Fit(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_Transform(/*in*/ OneHotEncoderFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_Transform(/*in*/ OneHotEncoderFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint16_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <uint32_t> */
-struct OneHotEncoderFeaturizer_uint32_t_EstimatorHandle {};
-struct OneHotEncoderFeaturizer_uint32_t_TransformerHandle {};
+/* |  OneHotEncoderFeaturizer <uint32> */
+struct OneHotEncoderFeaturizer_uint32_EstimatorHandle {};
+struct OneHotEncoderFeaturizer_uint32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_GetState(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_Fit(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_GetState(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_Fit(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_Transform(/*in*/ OneHotEncoderFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_Transform(/*in*/ OneHotEncoderFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint32_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <uint64_t> */
-struct OneHotEncoderFeaturizer_uint64_t_EstimatorHandle {};
-struct OneHotEncoderFeaturizer_uint64_t_TransformerHandle {};
+/* |  OneHotEncoderFeaturizer <uint64> */
+struct OneHotEncoderFeaturizer_uint64_EstimatorHandle {};
+struct OneHotEncoderFeaturizer_uint64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_GetState(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_Fit(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_GetState(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_Fit(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_FitBuffer(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_Transform(/*in*/ OneHotEncoderFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_Transform(/*in*/ OneHotEncoderFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_uint64_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <float_t> */
-struct OneHotEncoderFeaturizer_float_t_EstimatorHandle {};
-struct OneHotEncoderFeaturizer_float_t_TransformerHandle {};
+/* |  OneHotEncoderFeaturizer <float> */
+struct OneHotEncoderFeaturizer_float_EstimatorHandle {};
+struct OneHotEncoderFeaturizer_float_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_GetState(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_Fit(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_GetState(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_Fit(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_FitBuffer(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_Transform(/*in*/ OneHotEncoderFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_Transform(/*in*/ OneHotEncoderFeaturizer_float_TransformerHandle *pHandle, /*in*/ float input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_float_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <double_t> */
-struct OneHotEncoderFeaturizer_double_t_EstimatorHandle {};
-struct OneHotEncoderFeaturizer_double_t_TransformerHandle {};
+/* |  OneHotEncoderFeaturizer <double> */
+struct OneHotEncoderFeaturizer_double_EstimatorHandle {};
+struct OneHotEncoderFeaturizer_double_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_CreateEstimator(/*in*/ bool suppressUnrecognizedErrors,/*out*/ OneHotEncoderFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_DestroyEstimator(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_GetState(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_Fit(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_FitBuffer(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_GetState(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_IsTrainingComplete(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_Fit(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_FitBuffer(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_OnDataCompleted(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_CompleteTraining(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_CreateTransformerFromEstimator(/*in*/ OneHotEncoderFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ OneHotEncoderFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ OneHotEncoderFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_DestroyTransformer(/*in*/ OneHotEncoderFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_CreateTransformerSaveData(/*in*/ OneHotEncoderFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_Transform(/*in*/ OneHotEncoderFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_t_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_Transform(/*in*/ OneHotEncoderFeaturizer_double_TransformerHandle *pHandle, /*in*/ double input, /*out via struct*/ OneHotStruct * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool OneHotEncoderFeaturizer_double_DestroyTransformedData(/*in*/ OneHotStruct * result, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
 /* |  OneHotEncoderFeaturizer <bool> */

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_RobustScalarFeaturizer.cpp
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_RobustScalarFeaturizer.cpp
@@ -24,10 +24,10 @@ extern "C" {
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  RobustScalarFeaturizer <int8_t> */
+/* |  RobustScalarFeaturizer <int8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -35,12 +35,12 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateEstimator(/*in*/
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_int8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_int8_EstimatorHandle*>(index);
 
 
     
@@ -52,7 +52,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateEstimator(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -62,7 +62,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_DestroyEstimator(/*in*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -75,7 +75,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_DestroyEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_GetState(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_GetState(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -85,7 +85,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_GetState(/*in*/ Robust
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -97,7 +97,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_GetState(/*in*/ Robust
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -107,7 +107,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_IsTrainingComplete(/*i
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -119,7 +119,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_IsTrainingComplete(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_Fit(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_Fit(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -132,7 +132,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_Fit(/*in*/ RobustScala
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -145,7 +145,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_Fit(/*in*/ RobustScala
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_FitBuffer(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_FitBuffer(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -160,7 +160,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_FitBuffer(/*in*/ Robus
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -172,7 +172,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_FitBuffer(/*in*/ Robus
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -181,7 +181,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_OnDataCompleted(/*in*/
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -193,7 +193,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_OnDataCompleted(/*in*/
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_CompleteTraining(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -202,7 +202,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CompleteTraining(/*in*
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -214,7 +214,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CompleteTraining(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -226,13 +226,13 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateTransformerFromE
 
 
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -242,7 +242,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateTransformerFromE
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -255,10 +255,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateTransformerFromS
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -268,7 +268,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateTransformerFromS
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -278,7 +278,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_DestroyTransformer(/*i
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -292,7 +292,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_DestroyTransformer(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -303,7 +303,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateTransformerSaveD
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -325,7 +325,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateTransformerSaveD
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_Transform(/*in*/ RobustScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_Transform(/*in*/ RobustScalarFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -338,7 +338,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_Transform(/*in*/ Robus
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int8_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -356,10 +356,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_Transform(/*in*/ Robus
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  RobustScalarFeaturizer <int16_t> */
+/* |  RobustScalarFeaturizer <int16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -367,12 +367,12 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateEstimator(/*in*
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_int16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_int16_EstimatorHandle*>(index);
 
 
     
@@ -384,7 +384,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -394,7 +394,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_DestroyEstimator(/*in
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -407,7 +407,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_GetState(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_GetState(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -417,7 +417,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_GetState(/*in*/ Robus
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -429,7 +429,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_GetState(/*in*/ Robus
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -439,7 +439,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_IsTrainingComplete(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -451,7 +451,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_Fit(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_Fit(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -464,7 +464,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_Fit(/*in*/ RobustScal
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -477,7 +477,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_Fit(/*in*/ RobustScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_FitBuffer(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_FitBuffer(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -492,7 +492,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_FitBuffer(/*in*/ Robu
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -504,7 +504,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_FitBuffer(/*in*/ Robu
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -513,7 +513,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_OnDataCompleted(/*in*
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -525,7 +525,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_CompleteTraining(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -534,7 +534,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CompleteTraining(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -546,7 +546,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -558,13 +558,13 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateTransformerFrom
 
 
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -574,7 +574,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -587,10 +587,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateTransformerFrom
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -600,7 +600,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -610,7 +610,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_DestroyTransformer(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -624,7 +624,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -635,7 +635,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateTransformerSave
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -657,7 +657,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_Transform(/*in*/ RobustScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_Transform(/*in*/ RobustScalarFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -670,7 +670,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_Transform(/*in*/ Robu
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int16_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -688,10 +688,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_Transform(/*in*/ Robu
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  RobustScalarFeaturizer <uint8_t> */
+/* |  RobustScalarFeaturizer <uint8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -699,12 +699,12 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateEstimator(/*in*
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_uint8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_uint8_EstimatorHandle*>(index);
 
 
     
@@ -716,7 +716,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -726,7 +726,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_DestroyEstimator(/*in
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -739,7 +739,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_GetState(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_GetState(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -749,7 +749,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_GetState(/*in*/ Robus
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -761,7 +761,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_GetState(/*in*/ Robus
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -771,7 +771,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_IsTrainingComplete(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -783,7 +783,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_Fit(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_Fit(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -796,7 +796,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_Fit(/*in*/ RobustScal
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -809,7 +809,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_Fit(/*in*/ RobustScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_FitBuffer(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_FitBuffer(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -824,7 +824,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_FitBuffer(/*in*/ Robu
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -836,7 +836,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_FitBuffer(/*in*/ Robu
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -845,7 +845,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_OnDataCompleted(/*in*
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -857,7 +857,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -866,7 +866,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CompleteTraining(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -878,7 +878,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -890,13 +890,13 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateTransformerFrom
 
 
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -906,7 +906,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -919,10 +919,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateTransformerFrom
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -932,7 +932,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -942,7 +942,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_DestroyTransformer(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -956,7 +956,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -967,7 +967,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateTransformerSave
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -989,7 +989,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_Transform(/*in*/ RobustScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_Transform(/*in*/ RobustScalarFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1002,7 +1002,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_Transform(/*in*/ Robu
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint8_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -1020,10 +1020,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_Transform(/*in*/ Robu
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  RobustScalarFeaturizer <uint16_t> */
+/* |  RobustScalarFeaturizer <uint16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1031,12 +1031,12 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateEstimator(/*in
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_uint16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_uint16_EstimatorHandle*>(index);
 
 
     
@@ -1048,7 +1048,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1058,7 +1058,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_DestroyEstimator(/*i
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -1071,7 +1071,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_GetState(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_GetState(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1081,7 +1081,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_GetState(/*in*/ Robu
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -1093,7 +1093,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_GetState(/*in*/ Robu
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1103,7 +1103,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_IsTrainingComplete(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -1115,7 +1115,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_Fit(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_Fit(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1128,7 +1128,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_Fit(/*in*/ RobustSca
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -1141,7 +1141,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_Fit(/*in*/ RobustSca
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_FitBuffer(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_FitBuffer(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1156,7 +1156,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_FitBuffer(/*in*/ Rob
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -1168,7 +1168,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_FitBuffer(/*in*/ Rob
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1177,7 +1177,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_OnDataCompleted(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -1189,7 +1189,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1198,7 +1198,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CompleteTraining(/*i
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -1210,7 +1210,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1222,13 +1222,13 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateTransformerFro
 
 
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -1238,7 +1238,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1251,10 +1251,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateTransformerFro
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -1264,7 +1264,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1274,7 +1274,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_DestroyTransformer(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -1288,7 +1288,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1299,7 +1299,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateTransformerSav
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -1321,7 +1321,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_Transform(/*in*/ RobustScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_Transform(/*in*/ RobustScalarFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1334,7 +1334,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_Transform(/*in*/ Rob
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint16_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -1352,10 +1352,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_Transform(/*in*/ Rob
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  RobustScalarFeaturizer <float_t> */
+/* |  RobustScalarFeaturizer <float> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1363,12 +1363,12 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateEstimator(/*in*
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_float_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_float_EstimatorHandle*>(index);
 
 
     
@@ -1380,7 +1380,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_DestroyEstimator(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1390,7 +1390,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_DestroyEstimator(/*in
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -1403,7 +1403,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_GetState(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_GetState(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1413,7 +1413,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_GetState(/*in*/ Robus
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -1425,7 +1425,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_GetState(/*in*/ Robus
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1435,7 +1435,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_IsTrainingComplete(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -1447,7 +1447,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_Fit(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_Fit(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1460,7 +1460,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_Fit(/*in*/ RobustScal
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -1473,7 +1473,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_Fit(/*in*/ RobustScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_FitBuffer(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_FitBuffer(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1488,7 +1488,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_FitBuffer(/*in*/ Robu
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -1500,7 +1500,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_FitBuffer(/*in*/ Robu
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_OnDataCompleted(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1509,7 +1509,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_OnDataCompleted(/*in*
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -1521,7 +1521,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_CompleteTraining(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1530,7 +1530,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CompleteTraining(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -1542,7 +1542,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1554,13 +1554,13 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateTransformerFrom
 
 
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -1570,7 +1570,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1583,10 +1583,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateTransformerFrom
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -1596,7 +1596,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_DestroyTransformer(/*in*/ RobustScalarFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1606,7 +1606,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_DestroyTransformer(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -1620,7 +1620,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1631,7 +1631,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateTransformerSave
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -1653,7 +1653,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_Transform(/*in*/ RobustScalarFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_Transform(/*in*/ RobustScalarFeaturizer_float_TransformerHandle *pHandle, /*in*/ float input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1666,7 +1666,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_Transform(/*in*/ Robu
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, std::float_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::float_t, float>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -1684,10 +1684,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_Transform(/*in*/ Robu
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  RobustScalarFeaturizer <int32_t> */
+/* |  RobustScalarFeaturizer <int32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1695,12 +1695,12 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateEstimator(/*in*
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_int32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_int32_EstimatorHandle*>(index);
 
 
     
@@ -1712,7 +1712,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1722,7 +1722,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_DestroyEstimator(/*in
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -1735,7 +1735,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_GetState(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_GetState(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1745,7 +1745,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_GetState(/*in*/ Robus
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -1757,7 +1757,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_GetState(/*in*/ Robus
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1767,7 +1767,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_IsTrainingComplete(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -1779,7 +1779,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_Fit(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_Fit(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1792,7 +1792,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_Fit(/*in*/ RobustScal
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -1805,7 +1805,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_Fit(/*in*/ RobustScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_FitBuffer(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_FitBuffer(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1820,7 +1820,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_FitBuffer(/*in*/ Robu
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -1832,7 +1832,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_FitBuffer(/*in*/ Robu
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1841,7 +1841,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_OnDataCompleted(/*in*
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -1853,7 +1853,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_CompleteTraining(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1862,7 +1862,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CompleteTraining(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -1874,7 +1874,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1886,13 +1886,13 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateTransformerFrom
 
 
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -1902,7 +1902,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1915,10 +1915,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateTransformerFrom
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -1928,7 +1928,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1938,7 +1938,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_DestroyTransformer(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -1952,7 +1952,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1963,7 +1963,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateTransformerSave
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -1985,7 +1985,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_Transform(/*in*/ RobustScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_Transform(/*in*/ RobustScalarFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1998,7 +1998,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_Transform(/*in*/ Robu
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int32_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -2016,10 +2016,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_Transform(/*in*/ Robu
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  RobustScalarFeaturizer <int64_t> */
+/* |  RobustScalarFeaturizer <int64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2027,12 +2027,12 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateEstimator(/*in*
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_int64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_int64_EstimatorHandle*>(index);
 
 
     
@@ -2044,7 +2044,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateEstimator(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2054,7 +2054,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_DestroyEstimator(/*in
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -2067,7 +2067,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_DestroyEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_GetState(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_GetState(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2077,7 +2077,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_GetState(/*in*/ Robus
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -2089,7 +2089,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_GetState(/*in*/ Robus
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2099,7 +2099,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_IsTrainingComplete(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -2111,7 +2111,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_IsTrainingComplete(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_Fit(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_Fit(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2124,7 +2124,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_Fit(/*in*/ RobustScal
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -2137,7 +2137,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_Fit(/*in*/ RobustScal
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_FitBuffer(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_FitBuffer(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2152,7 +2152,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_FitBuffer(/*in*/ Robu
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -2164,7 +2164,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_FitBuffer(/*in*/ Robu
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2173,7 +2173,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_OnDataCompleted(/*in*
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -2185,7 +2185,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_OnDataCompleted(/*in*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_CompleteTraining(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2194,7 +2194,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CompleteTraining(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -2206,7 +2206,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CompleteTraining(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2218,13 +2218,13 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateTransformerFrom
 
 
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2234,7 +2234,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2247,10 +2247,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateTransformerFrom
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2260,7 +2260,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateTransformerFrom
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2270,7 +2270,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_DestroyTransformer(/*
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -2284,7 +2284,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_DestroyTransformer(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2295,7 +2295,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateTransformerSave
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -2317,7 +2317,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateTransformerSave
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_Transform(/*in*/ RobustScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_Transform(/*in*/ RobustScalarFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2330,7 +2330,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_Transform(/*in*/ Robu
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::int64_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -2348,10 +2348,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_Transform(/*in*/ Robu
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  RobustScalarFeaturizer <uint32_t> */
+/* |  RobustScalarFeaturizer <uint32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2359,12 +2359,12 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateEstimator(/*in
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_uint32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_uint32_EstimatorHandle*>(index);
 
 
     
@@ -2376,7 +2376,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2386,7 +2386,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_DestroyEstimator(/*i
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -2399,7 +2399,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_GetState(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_GetState(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2409,7 +2409,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_GetState(/*in*/ Robu
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -2421,7 +2421,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_GetState(/*in*/ Robu
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2431,7 +2431,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_IsTrainingComplete(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -2443,7 +2443,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_Fit(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_Fit(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2456,7 +2456,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_Fit(/*in*/ RobustSca
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -2469,7 +2469,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_Fit(/*in*/ RobustSca
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_FitBuffer(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_FitBuffer(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2484,7 +2484,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_FitBuffer(/*in*/ Rob
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -2496,7 +2496,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_FitBuffer(/*in*/ Rob
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2505,7 +2505,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_OnDataCompleted(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -2517,7 +2517,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2526,7 +2526,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CompleteTraining(/*i
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -2538,7 +2538,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2550,13 +2550,13 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateTransformerFro
 
 
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2566,7 +2566,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2579,10 +2579,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateTransformerFro
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2592,7 +2592,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2602,7 +2602,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_DestroyTransformer(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -2616,7 +2616,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2627,7 +2627,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateTransformerSav
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -2649,7 +2649,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_Transform(/*in*/ RobustScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_Transform(/*in*/ RobustScalarFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2662,7 +2662,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_Transform(/*in*/ Rob
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint32_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -2680,10 +2680,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_Transform(/*in*/ Rob
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  RobustScalarFeaturizer <uint64_t> */
+/* |  RobustScalarFeaturizer <uint64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2691,12 +2691,12 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateEstimator(/*in
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_uint64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_uint64_EstimatorHandle*>(index);
 
 
     
@@ -2708,7 +2708,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2718,7 +2718,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_DestroyEstimator(/*i
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -2731,7 +2731,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_GetState(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_GetState(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2741,7 +2741,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_GetState(/*in*/ Robu
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -2753,7 +2753,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_GetState(/*in*/ Robu
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2763,7 +2763,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_IsTrainingComplete(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -2775,7 +2775,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_Fit(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_Fit(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2788,7 +2788,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_Fit(/*in*/ RobustSca
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -2801,7 +2801,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_Fit(/*in*/ RobustSca
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_FitBuffer(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_FitBuffer(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2816,7 +2816,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_FitBuffer(/*in*/ Rob
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -2828,7 +2828,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_FitBuffer(/*in*/ Rob
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2837,7 +2837,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_OnDataCompleted(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -2849,7 +2849,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2858,7 +2858,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CompleteTraining(/*i
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -2870,7 +2870,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2882,13 +2882,13 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateTransformerFro
 
 
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2898,7 +2898,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2911,10 +2911,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateTransformerFro
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2924,7 +2924,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2934,7 +2934,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_DestroyTransformer(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -2948,7 +2948,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2959,7 +2959,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateTransformerSav
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -2981,7 +2981,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_Transform(/*in*/ RobustScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_Transform(/*in*/ RobustScalarFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2994,7 +2994,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_Transform(/*in*/ Rob
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::uint64_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));
@@ -3012,10 +3012,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_Transform(/*in*/ Rob
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  RobustScalarFeaturizer <double_t> */
+/* |  RobustScalarFeaturizer <double> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax, /*out*/ RobustScalarFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3023,12 +3023,12 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateEstimator(/*in
         *ppErrorInfo = nullptr;
 
         // No validation
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>* pEstimator = new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>(std::make_shared<Microsoft::Featurizer::AnnotationMaps>(1), 0 , withCentering, qRangeMin != nullptr ? *qRangeMin : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue(), qRangeMax != nullptr ? *qRangeMax : Microsoft::Featurizer::Traits<std::float_t>::CreateNullValue());
 
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_double_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<RobustScalarFeaturizer_double_EstimatorHandle*>(index);
 
 
     
@@ -3040,7 +3040,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateEstimator(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_DestroyEstimator(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3050,7 +3050,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_DestroyEstimator(/*i
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double> * pEstimator = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>>(index);
         g_pointerTable.Remove(index);
 
         delete pEstimator;
@@ -3063,7 +3063,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_DestroyEstimator(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_GetState(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_GetState(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3073,7 +3073,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_GetState(/*in*/ Robu
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pState == nullptr) throw std::invalid_argument("'pState' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pState = static_cast<TrainingState>(estimator.get_state());
     
@@ -3085,7 +3085,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_GetState(/*in*/ Robu
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3095,7 +3095,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_IsTrainingComplete(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
         if(pIsTrainingComplete == nullptr) throw std::invalid_argument("'pIsTrainingComplete' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double> const & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pIsTrainingComplete = estimator.get_state() != Microsoft::Featurizer::TrainingState::Training;
     
@@ -3107,7 +3107,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_IsTrainingComplete(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_Fit(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_Fit(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3120,7 +3120,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_Fit(/*in*/ RobustSca
 
         // No validation
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input));
@@ -3133,7 +3133,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_Fit(/*in*/ RobustSca
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_FitBuffer(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_FitBuffer(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3148,7 +3148,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_FitBuffer(/*in*/ Rob
         if(input_ptr == nullptr) throw std::invalid_argument("'input_ptr' is null");
         if(input_items == 0) throw std::invalid_argument("'input_items' is 0");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         *pFitResult = static_cast<unsigned char>(estimator.fit(input_ptr, input_items));
     
@@ -3160,7 +3160,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_FitBuffer(/*in*/ Rob
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_OnDataCompleted(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3169,7 +3169,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_OnDataCompleted(/*in
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.on_data_completed();
     
@@ -3181,7 +3181,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_OnDataCompleted(/*in
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_CompleteTraining(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3190,7 +3190,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CompleteTraining(/*i
 
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>>(reinterpret_cast<size_t>(pHandle)));
 
         estimator.complete_training();
     
@@ -3202,7 +3202,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CompleteTraining(/*i
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3214,13 +3214,13 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateTransformerFro
 
 
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>>(reinterpret_cast<size_t>(pEstimatorHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double> & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>>(reinterpret_cast<size_t>(pEstimatorHandle)));
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>::TransformerType*>(estimator.create_transformer().release());
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>::TransformerType * pTransformer = reinterpret_cast<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>::TransformerType*>(estimator.create_transformer().release());
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3230,7 +3230,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3243,10 +3243,10 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateTransformerFro
 
         Microsoft::Featurizer::Archive archive(pBuffer, cBufferSize);
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>::TransformerType(archive));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<RobustScalarFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3256,7 +3256,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateTransformerFro
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_DestroyTransformer(/*in*/ RobustScalarFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3266,7 +3266,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_DestroyTransformer(/
         if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
 
         size_t index = reinterpret_cast<size_t>(pHandle);
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>::TransformerType>(index);
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>::TransformerType* pTransformer = g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>::TransformerType>(index);
         g_pointerTable.Remove(index);
 
 
@@ -3280,7 +3280,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_DestroyTransformer(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3291,7 +3291,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateTransformerSav
         if(ppBuffer == nullptr) throw std::invalid_argument("'ppBuffer' is null");
         if(pBufferSize == nullptr) throw std::invalid_argument("'pBufferSize' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
         Microsoft::Featurizer::Archive archive;
 
         transformer.save(archive);
@@ -3313,7 +3313,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateTransformerSav
     }
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_Transform(/*in*/ RobustScalarFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_Transform(/*in*/ RobustScalarFeaturizer_double_TransformerHandle *pHandle, /*in*/ double input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3326,7 +3326,7 @@ FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_Transform(/*in*/ Rob
         // No input validation
         if(output == nullptr) throw std::invalid_argument("'output' is null");
 
-        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, std::double_t>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
+        Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>::TransformerType & transformer(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::RobustScalarEstimator<std::double_t, double>::TransformerType>(reinterpret_cast<size_t>(pHandle)));
 
         // Input
         auto result(transformer.execute(input));

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_RobustScalarFeaturizer.h
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_RobustScalarFeaturizer.h
@@ -9,253 +9,253 @@
 extern "C" {
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <int8_t> */
-struct RobustScalarFeaturizer_int8_t_EstimatorHandle {};
-struct RobustScalarFeaturizer_int8_t_TransformerHandle {};
+/* |  RobustScalarFeaturizer <int8> */
+struct RobustScalarFeaturizer_int8_EstimatorHandle {};
+struct RobustScalarFeaturizer_int8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_GetState(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_Fit(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_FitBuffer(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_GetState(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_Fit(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_FitBuffer(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_CompleteTraining(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_Transform(/*in*/ RobustScalarFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_Transform(/*in*/ RobustScalarFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <int16_t> */
-struct RobustScalarFeaturizer_int16_t_EstimatorHandle {};
-struct RobustScalarFeaturizer_int16_t_TransformerHandle {};
+/* |  RobustScalarFeaturizer <int16> */
+struct RobustScalarFeaturizer_int16_EstimatorHandle {};
+struct RobustScalarFeaturizer_int16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_GetState(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_Fit(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_FitBuffer(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_GetState(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_Fit(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_FitBuffer(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_CompleteTraining(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_Transform(/*in*/ RobustScalarFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_Transform(/*in*/ RobustScalarFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <uint8_t> */
-struct RobustScalarFeaturizer_uint8_t_EstimatorHandle {};
-struct RobustScalarFeaturizer_uint8_t_TransformerHandle {};
+/* |  RobustScalarFeaturizer <uint8> */
+struct RobustScalarFeaturizer_uint8_EstimatorHandle {};
+struct RobustScalarFeaturizer_uint8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_GetState(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_Fit(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_FitBuffer(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_GetState(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_Fit(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_FitBuffer(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_Transform(/*in*/ RobustScalarFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_Transform(/*in*/ RobustScalarFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <uint16_t> */
-struct RobustScalarFeaturizer_uint16_t_EstimatorHandle {};
-struct RobustScalarFeaturizer_uint16_t_TransformerHandle {};
+/* |  RobustScalarFeaturizer <uint16> */
+struct RobustScalarFeaturizer_uint16_EstimatorHandle {};
+struct RobustScalarFeaturizer_uint16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_GetState(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_Fit(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_FitBuffer(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_GetState(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_Fit(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_FitBuffer(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_Transform(/*in*/ RobustScalarFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_Transform(/*in*/ RobustScalarFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <float_t> */
-struct RobustScalarFeaturizer_float_t_EstimatorHandle {};
-struct RobustScalarFeaturizer_float_t_TransformerHandle {};
+/* |  RobustScalarFeaturizer <float> */
+struct RobustScalarFeaturizer_float_EstimatorHandle {};
+struct RobustScalarFeaturizer_float_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_DestroyEstimator(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_GetState(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_Fit(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_FitBuffer(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_GetState(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_Fit(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_FitBuffer(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_OnDataCompleted(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_CompleteTraining(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_DestroyTransformer(/*in*/ RobustScalarFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_Transform(/*in*/ RobustScalarFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_Transform(/*in*/ RobustScalarFeaturizer_float_TransformerHandle *pHandle, /*in*/ float input, /*out*/ float * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <int32_t> */
-struct RobustScalarFeaturizer_int32_t_EstimatorHandle {};
-struct RobustScalarFeaturizer_int32_t_TransformerHandle {};
+/* |  RobustScalarFeaturizer <int32> */
+struct RobustScalarFeaturizer_int32_EstimatorHandle {};
+struct RobustScalarFeaturizer_int32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_GetState(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_Fit(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_FitBuffer(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_GetState(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_Fit(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_FitBuffer(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_CompleteTraining(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_Transform(/*in*/ RobustScalarFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_Transform(/*in*/ RobustScalarFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <int64_t> */
-struct RobustScalarFeaturizer_int64_t_EstimatorHandle {};
-struct RobustScalarFeaturizer_int64_t_TransformerHandle {};
+/* |  RobustScalarFeaturizer <int64> */
+struct RobustScalarFeaturizer_int64_EstimatorHandle {};
+struct RobustScalarFeaturizer_int64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_DestroyEstimator(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_GetState(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_Fit(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_FitBuffer(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_GetState(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_Fit(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_FitBuffer(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_OnDataCompleted(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_CompleteTraining(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_DestroyTransformer(/*in*/ RobustScalarFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_Transform(/*in*/ RobustScalarFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_Transform(/*in*/ RobustScalarFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <uint32_t> */
-struct RobustScalarFeaturizer_uint32_t_EstimatorHandle {};
-struct RobustScalarFeaturizer_uint32_t_TransformerHandle {};
+/* |  RobustScalarFeaturizer <uint32> */
+struct RobustScalarFeaturizer_uint32_EstimatorHandle {};
+struct RobustScalarFeaturizer_uint32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_GetState(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_Fit(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_FitBuffer(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_GetState(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_Fit(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_FitBuffer(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_Transform(/*in*/ RobustScalarFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_Transform(/*in*/ RobustScalarFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <uint64_t> */
-struct RobustScalarFeaturizer_uint64_t_EstimatorHandle {};
-struct RobustScalarFeaturizer_uint64_t_TransformerHandle {};
+/* |  RobustScalarFeaturizer <uint64> */
+struct RobustScalarFeaturizer_uint64_EstimatorHandle {};
+struct RobustScalarFeaturizer_uint64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_DestroyEstimator(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_GetState(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_Fit(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_FitBuffer(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_GetState(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_Fit(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_FitBuffer(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_OnDataCompleted(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_CompleteTraining(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_DestroyTransformer(/*in*/ RobustScalarFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_Transform(/*in*/ RobustScalarFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_Transform(/*in*/ RobustScalarFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <double_t> */
-struct RobustScalarFeaturizer_double_t_EstimatorHandle {};
-struct RobustScalarFeaturizer_double_t_TransformerHandle {};
+/* |  RobustScalarFeaturizer <double> */
+struct RobustScalarFeaturizer_double_EstimatorHandle {};
+struct RobustScalarFeaturizer_double_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_DestroyEstimator(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_CreateEstimator(/*in*/ bool withCentering, /*in*/ float const * qRangeMin, /*in*/ float const * qRangeMax,/*out*/ RobustScalarFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_DestroyEstimator(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_GetState(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_Fit(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_FitBuffer(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_OnDataCompleted(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CompleteTraining(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_GetState(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_IsTrainingComplete(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_Fit(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_FitBuffer(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_OnDataCompleted(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_CompleteTraining(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_DestroyTransformer(/*in*/ RobustScalarFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_CreateTransformerFromEstimator(/*in*/ RobustScalarFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ RobustScalarFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ RobustScalarFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_DestroyTransformer(/*in*/ RobustScalarFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_CreateTransformerSaveData(/*in*/ RobustScalarFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_Transform(/*in*/ RobustScalarFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_Transform(/*in*/ RobustScalarFeaturizer_double_TransformerHandle *pHandle, /*in*/ double input, /*out*/ double * output, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 } // extern "C"

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_StringFeaturizer.cpp
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_StringFeaturizer.cpp
@@ -24,10 +24,10 @@ extern "C" {
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  StringFeaturizer <int8_t> */
+/* |  StringFeaturizer <int8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateEstimator(/*out*/ StringFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_CreateEstimator(/*out*/ StringFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -40,7 +40,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateEstimator(/*out*/ Stri
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<StringFeaturizer_int8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<StringFeaturizer_int8_EstimatorHandle*>(index);
 
 
     
@@ -52,7 +52,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateEstimator(/*out*/ Stri
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_DestroyEstimator(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_DestroyEstimator(/*in*/ StringFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -75,7 +75,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_DestroyEstimator(/*in*/ Stri
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_GetState(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_GetState(/*in*/ StringFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -97,7 +97,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_GetState(/*in*/ StringFeatur
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_IsTrainingComplete(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_IsTrainingComplete(/*in*/ StringFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -119,7 +119,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_IsTrainingComplete(/*in*/ St
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_Fit(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_Fit(/*in*/ StringFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -145,7 +145,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_Fit(/*in*/ StringFeaturizer_
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_FitBuffer(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_FitBuffer(/*in*/ StringFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -172,7 +172,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_FitBuffer(/*in*/ StringFeatu
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_OnDataCompleted(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_OnDataCompleted(/*in*/ StringFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -193,7 +193,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_OnDataCompleted(/*in*/ Strin
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CompleteTraining(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_CompleteTraining(/*in*/ StringFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -214,7 +214,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CompleteTraining(/*in*/ Stri
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -232,7 +232,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateTransformerFromEstimat
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -242,7 +242,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateTransformerFromEstimat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -258,7 +258,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateTransformerFromSavedDa
         Microsoft::Featurizer::Featurizers::StringEstimator<std::int8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::StringEstimator<std::int8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int8_TransformerHandle*>(index);
     
         return true;
     }
@@ -268,7 +268,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateTransformerFromSavedDa
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_DestroyTransformer(/*in*/ StringFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_DestroyTransformer(/*in*/ StringFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -292,7 +292,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_DestroyTransformer(/*in*/ St
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_CreateTransformerSaveData(/*in*/ StringFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -325,7 +325,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateTransformerSaveData(/*
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_Transform(/*in*/ StringFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_Transform(/*in*/ StringFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -367,7 +367,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_Transform(/*in*/ StringFeatu
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -390,10 +390,10 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_DestroyTransformedData(/*in*
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  StringFeaturizer <int16_t> */
+/* |  StringFeaturizer <int16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateEstimator(/*out*/ StringFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_CreateEstimator(/*out*/ StringFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -406,7 +406,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateEstimator(/*out*/ Str
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<StringFeaturizer_int16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<StringFeaturizer_int16_EstimatorHandle*>(index);
 
 
     
@@ -418,7 +418,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateEstimator(/*out*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_DestroyEstimator(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_DestroyEstimator(/*in*/ StringFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -441,7 +441,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_DestroyEstimator(/*in*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_GetState(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_GetState(/*in*/ StringFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -463,7 +463,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_GetState(/*in*/ StringFeatu
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_IsTrainingComplete(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_IsTrainingComplete(/*in*/ StringFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -485,7 +485,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_IsTrainingComplete(/*in*/ S
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_Fit(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_Fit(/*in*/ StringFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -511,7 +511,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_Fit(/*in*/ StringFeaturizer
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_FitBuffer(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_FitBuffer(/*in*/ StringFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -538,7 +538,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_FitBuffer(/*in*/ StringFeat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_OnDataCompleted(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_OnDataCompleted(/*in*/ StringFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -559,7 +559,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_OnDataCompleted(/*in*/ Stri
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CompleteTraining(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_CompleteTraining(/*in*/ StringFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -580,7 +580,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CompleteTraining(/*in*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -598,7 +598,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateTransformerFromEstima
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -608,7 +608,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateTransformerFromEstima
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -624,7 +624,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateTransformerFromSavedD
         Microsoft::Featurizer::Featurizers::StringEstimator<std::int16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::StringEstimator<std::int16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int16_TransformerHandle*>(index);
     
         return true;
     }
@@ -634,7 +634,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateTransformerFromSavedD
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_DestroyTransformer(/*in*/ StringFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_DestroyTransformer(/*in*/ StringFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -658,7 +658,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_DestroyTransformer(/*in*/ S
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_CreateTransformerSaveData(/*in*/ StringFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -691,7 +691,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateTransformerSaveData(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_Transform(/*in*/ StringFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_Transform(/*in*/ StringFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -733,7 +733,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_Transform(/*in*/ StringFeat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -756,10 +756,10 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_DestroyTransformedData(/*in
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  StringFeaturizer <int32_t> */
+/* |  StringFeaturizer <int32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateEstimator(/*out*/ StringFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_CreateEstimator(/*out*/ StringFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -772,7 +772,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateEstimator(/*out*/ Str
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<StringFeaturizer_int32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<StringFeaturizer_int32_EstimatorHandle*>(index);
 
 
     
@@ -784,7 +784,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateEstimator(/*out*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_DestroyEstimator(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_DestroyEstimator(/*in*/ StringFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -807,7 +807,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_DestroyEstimator(/*in*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_GetState(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_GetState(/*in*/ StringFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -829,7 +829,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_GetState(/*in*/ StringFeatu
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_IsTrainingComplete(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_IsTrainingComplete(/*in*/ StringFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -851,7 +851,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_IsTrainingComplete(/*in*/ S
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_Fit(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_Fit(/*in*/ StringFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -877,7 +877,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_Fit(/*in*/ StringFeaturizer
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_FitBuffer(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_FitBuffer(/*in*/ StringFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -904,7 +904,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_FitBuffer(/*in*/ StringFeat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_OnDataCompleted(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_OnDataCompleted(/*in*/ StringFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -925,7 +925,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_OnDataCompleted(/*in*/ Stri
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CompleteTraining(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_CompleteTraining(/*in*/ StringFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -946,7 +946,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CompleteTraining(/*in*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -964,7 +964,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateTransformerFromEstima
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -974,7 +974,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateTransformerFromEstima
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -990,7 +990,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateTransformerFromSavedD
         Microsoft::Featurizer::Featurizers::StringEstimator<std::int32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::StringEstimator<std::int32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int32_TransformerHandle*>(index);
     
         return true;
     }
@@ -1000,7 +1000,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateTransformerFromSavedD
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_DestroyTransformer(/*in*/ StringFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_DestroyTransformer(/*in*/ StringFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1024,7 +1024,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_DestroyTransformer(/*in*/ S
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_CreateTransformerSaveData(/*in*/ StringFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1057,7 +1057,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateTransformerSaveData(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_Transform(/*in*/ StringFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_Transform(/*in*/ StringFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1099,7 +1099,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_Transform(/*in*/ StringFeat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1122,10 +1122,10 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_DestroyTransformedData(/*in
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  StringFeaturizer <int64_t> */
+/* |  StringFeaturizer <int64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateEstimator(/*out*/ StringFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_CreateEstimator(/*out*/ StringFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1138,7 +1138,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateEstimator(/*out*/ Str
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<StringFeaturizer_int64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<StringFeaturizer_int64_EstimatorHandle*>(index);
 
 
     
@@ -1150,7 +1150,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateEstimator(/*out*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_DestroyEstimator(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_DestroyEstimator(/*in*/ StringFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1173,7 +1173,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_DestroyEstimator(/*in*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_GetState(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_GetState(/*in*/ StringFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1195,7 +1195,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_GetState(/*in*/ StringFeatu
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_IsTrainingComplete(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_IsTrainingComplete(/*in*/ StringFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1217,7 +1217,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_IsTrainingComplete(/*in*/ S
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_Fit(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_Fit(/*in*/ StringFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1243,7 +1243,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_Fit(/*in*/ StringFeaturizer
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_FitBuffer(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_FitBuffer(/*in*/ StringFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1270,7 +1270,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_FitBuffer(/*in*/ StringFeat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_OnDataCompleted(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_OnDataCompleted(/*in*/ StringFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1291,7 +1291,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_OnDataCompleted(/*in*/ Stri
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CompleteTraining(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_CompleteTraining(/*in*/ StringFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1312,7 +1312,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CompleteTraining(/*in*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1330,7 +1330,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateTransformerFromEstima
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1340,7 +1340,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateTransformerFromEstima
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1356,7 +1356,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateTransformerFromSavedD
         Microsoft::Featurizer::Featurizers::StringEstimator<std::int64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::StringEstimator<std::int64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_int64_TransformerHandle*>(index);
     
         return true;
     }
@@ -1366,7 +1366,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateTransformerFromSavedD
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_DestroyTransformer(/*in*/ StringFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_DestroyTransformer(/*in*/ StringFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1390,7 +1390,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_DestroyTransformer(/*in*/ S
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_CreateTransformerSaveData(/*in*/ StringFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1423,7 +1423,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateTransformerSaveData(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_Transform(/*in*/ StringFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_Transform(/*in*/ StringFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1465,7 +1465,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_Transform(/*in*/ StringFeat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1488,10 +1488,10 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_DestroyTransformedData(/*in
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  StringFeaturizer <uint8_t> */
+/* |  StringFeaturizer <uint8> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateEstimator(/*out*/ StringFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_CreateEstimator(/*out*/ StringFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1504,7 +1504,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateEstimator(/*out*/ Str
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<StringFeaturizer_uint8_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<StringFeaturizer_uint8_EstimatorHandle*>(index);
 
 
     
@@ -1516,7 +1516,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateEstimator(/*out*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_DestroyEstimator(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_DestroyEstimator(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1539,7 +1539,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_DestroyEstimator(/*in*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_GetState(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_GetState(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1561,7 +1561,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_GetState(/*in*/ StringFeatu
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_IsTrainingComplete(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_IsTrainingComplete(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1583,7 +1583,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_IsTrainingComplete(/*in*/ S
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_Fit(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_Fit(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1609,7 +1609,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_Fit(/*in*/ StringFeaturizer
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_FitBuffer(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_FitBuffer(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1636,7 +1636,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_FitBuffer(/*in*/ StringFeat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_OnDataCompleted(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_OnDataCompleted(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1657,7 +1657,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_OnDataCompleted(/*in*/ Stri
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CompleteTraining(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_CompleteTraining(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1678,7 +1678,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CompleteTraining(/*in*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1696,7 +1696,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateTransformerFromEstima
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1706,7 +1706,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateTransformerFromEstima
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1722,7 +1722,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateTransformerFromSavedD
         Microsoft::Featurizer::Featurizers::StringEstimator<std::uint8_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::StringEstimator<std::uint8_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint8_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint8_TransformerHandle*>(index);
     
         return true;
     }
@@ -1732,7 +1732,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateTransformerFromSavedD
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_DestroyTransformer(/*in*/ StringFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_DestroyTransformer(/*in*/ StringFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1756,7 +1756,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_DestroyTransformer(/*in*/ S
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1789,7 +1789,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateTransformerSaveData(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_Transform(/*in*/ StringFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_Transform(/*in*/ StringFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1831,7 +1831,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_Transform(/*in*/ StringFeat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1854,10 +1854,10 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_DestroyTransformedData(/*in
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  StringFeaturizer <uint16_t> */
+/* |  StringFeaturizer <uint16> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateEstimator(/*out*/ StringFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_CreateEstimator(/*out*/ StringFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1870,7 +1870,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateEstimator(/*out*/ St
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<StringFeaturizer_uint16_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<StringFeaturizer_uint16_EstimatorHandle*>(index);
 
 
     
@@ -1882,7 +1882,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateEstimator(/*out*/ St
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_DestroyEstimator(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_DestroyEstimator(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1905,7 +1905,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_DestroyEstimator(/*in*/ St
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_GetState(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_GetState(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1927,7 +1927,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_GetState(/*in*/ StringFeat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_IsTrainingComplete(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_IsTrainingComplete(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1949,7 +1949,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_IsTrainingComplete(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_Fit(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_Fit(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -1975,7 +1975,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_Fit(/*in*/ StringFeaturize
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_FitBuffer(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_FitBuffer(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2002,7 +2002,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_FitBuffer(/*in*/ StringFea
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_OnDataCompleted(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_OnDataCompleted(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2023,7 +2023,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_OnDataCompleted(/*in*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CompleteTraining(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_CompleteTraining(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2044,7 +2044,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CompleteTraining(/*in*/ St
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2062,7 +2062,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateTransformerFromEstim
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -2072,7 +2072,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateTransformerFromEstim
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2088,7 +2088,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateTransformerFromSaved
         Microsoft::Featurizer::Featurizers::StringEstimator<std::uint16_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::StringEstimator<std::uint16_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint16_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint16_TransformerHandle*>(index);
     
         return true;
     }
@@ -2098,7 +2098,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateTransformerFromSaved
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_DestroyTransformer(/*in*/ StringFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_DestroyTransformer(/*in*/ StringFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2122,7 +2122,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_DestroyTransformer(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2155,7 +2155,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateTransformerSaveData(
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_Transform(/*in*/ StringFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_Transform(/*in*/ StringFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2197,7 +2197,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_Transform(/*in*/ StringFea
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2220,10 +2220,10 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_DestroyTransformedData(/*i
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  StringFeaturizer <uint32_t> */
+/* |  StringFeaturizer <uint32> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateEstimator(/*out*/ StringFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_CreateEstimator(/*out*/ StringFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2236,7 +2236,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateEstimator(/*out*/ St
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<StringFeaturizer_uint32_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<StringFeaturizer_uint32_EstimatorHandle*>(index);
 
 
     
@@ -2248,7 +2248,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateEstimator(/*out*/ St
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_DestroyEstimator(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_DestroyEstimator(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2271,7 +2271,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_DestroyEstimator(/*in*/ St
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_GetState(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_GetState(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2293,7 +2293,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_GetState(/*in*/ StringFeat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_IsTrainingComplete(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_IsTrainingComplete(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2315,7 +2315,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_IsTrainingComplete(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_Fit(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_Fit(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2341,7 +2341,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_Fit(/*in*/ StringFeaturize
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_FitBuffer(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_FitBuffer(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2368,7 +2368,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_FitBuffer(/*in*/ StringFea
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_OnDataCompleted(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_OnDataCompleted(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2389,7 +2389,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_OnDataCompleted(/*in*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CompleteTraining(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_CompleteTraining(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2410,7 +2410,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CompleteTraining(/*in*/ St
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2428,7 +2428,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateTransformerFromEstim
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2438,7 +2438,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateTransformerFromEstim
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2454,7 +2454,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateTransformerFromSaved
         Microsoft::Featurizer::Featurizers::StringEstimator<std::uint32_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::StringEstimator<std::uint32_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint32_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint32_TransformerHandle*>(index);
     
         return true;
     }
@@ -2464,7 +2464,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateTransformerFromSaved
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_DestroyTransformer(/*in*/ StringFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_DestroyTransformer(/*in*/ StringFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2488,7 +2488,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_DestroyTransformer(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2521,7 +2521,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateTransformerSaveData(
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_Transform(/*in*/ StringFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_Transform(/*in*/ StringFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2563,7 +2563,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_Transform(/*in*/ StringFea
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2586,10 +2586,10 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_DestroyTransformedData(/*i
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  StringFeaturizer <uint64_t> */
+/* |  StringFeaturizer <uint64> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateEstimator(/*out*/ StringFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_CreateEstimator(/*out*/ StringFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2602,7 +2602,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateEstimator(/*out*/ St
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<StringFeaturizer_uint64_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<StringFeaturizer_uint64_EstimatorHandle*>(index);
 
 
     
@@ -2614,7 +2614,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateEstimator(/*out*/ St
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_DestroyEstimator(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_DestroyEstimator(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2637,7 +2637,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_DestroyEstimator(/*in*/ St
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_GetState(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_GetState(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2659,7 +2659,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_GetState(/*in*/ StringFeat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_IsTrainingComplete(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_IsTrainingComplete(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2681,7 +2681,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_IsTrainingComplete(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_Fit(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_Fit(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2707,7 +2707,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_Fit(/*in*/ StringFeaturize
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_FitBuffer(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_FitBuffer(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2734,7 +2734,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_FitBuffer(/*in*/ StringFea
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_OnDataCompleted(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_OnDataCompleted(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2755,7 +2755,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_OnDataCompleted(/*in*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CompleteTraining(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_CompleteTraining(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2776,7 +2776,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CompleteTraining(/*in*/ St
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2794,7 +2794,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateTransformerFromEstim
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2804,7 +2804,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateTransformerFromEstim
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2820,7 +2820,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateTransformerFromSaved
         Microsoft::Featurizer::Featurizers::StringEstimator<std::uint64_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::StringEstimator<std::uint64_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint64_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_uint64_TransformerHandle*>(index);
     
         return true;
     }
@@ -2830,7 +2830,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateTransformerFromSaved
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_DestroyTransformer(/*in*/ StringFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_DestroyTransformer(/*in*/ StringFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2854,7 +2854,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_DestroyTransformer(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2887,7 +2887,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateTransformerSaveData(
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_Transform(/*in*/ StringFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_Transform(/*in*/ StringFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2929,7 +2929,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_Transform(/*in*/ StringFea
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2952,10 +2952,10 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_DestroyTransformedData(/*i
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  StringFeaturizer <float_t> */
+/* |  StringFeaturizer <float> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateEstimator(/*out*/ StringFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_CreateEstimator(/*out*/ StringFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -2968,7 +2968,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateEstimator(/*out*/ Str
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<StringFeaturizer_float_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<StringFeaturizer_float_EstimatorHandle*>(index);
 
 
     
@@ -2980,7 +2980,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateEstimator(/*out*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_DestroyEstimator(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_DestroyEstimator(/*in*/ StringFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3003,7 +3003,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_DestroyEstimator(/*in*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_GetState(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_GetState(/*in*/ StringFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3025,7 +3025,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_GetState(/*in*/ StringFeatu
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_IsTrainingComplete(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_IsTrainingComplete(/*in*/ StringFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3047,7 +3047,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_IsTrainingComplete(/*in*/ S
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_Fit(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_Fit(/*in*/ StringFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3073,7 +3073,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_Fit(/*in*/ StringFeaturizer
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_FitBuffer(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_FitBuffer(/*in*/ StringFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3100,7 +3100,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_FitBuffer(/*in*/ StringFeat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_OnDataCompleted(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_OnDataCompleted(/*in*/ StringFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3121,7 +3121,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_OnDataCompleted(/*in*/ Stri
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CompleteTraining(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_CompleteTraining(/*in*/ StringFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3142,7 +3142,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CompleteTraining(/*in*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3160,7 +3160,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateTransformerFromEstima
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -3170,7 +3170,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateTransformerFromEstima
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3186,7 +3186,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateTransformerFromSavedD
         Microsoft::Featurizer::Featurizers::StringEstimator<std::float_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::StringEstimator<std::float_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_float_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_float_TransformerHandle*>(index);
     
         return true;
     }
@@ -3196,7 +3196,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateTransformerFromSavedD
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_DestroyTransformer(/*in*/ StringFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_DestroyTransformer(/*in*/ StringFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3220,7 +3220,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_DestroyTransformer(/*in*/ S
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_CreateTransformerSaveData(/*in*/ StringFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3253,7 +3253,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateTransformerSaveData(/
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_Transform(/*in*/ StringFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_Transform(/*in*/ StringFeaturizer_float_TransformerHandle *pHandle, /*in*/ float input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3295,7 +3295,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_Transform(/*in*/ StringFeat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3318,10 +3318,10 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_DestroyTransformedData(/*in
 
 /* ---------------------------------------------------------------------- */
 /* |                                                                      */
-/* |  StringFeaturizer <double_t> */
+/* |  StringFeaturizer <double> */
 /* |                                                                      */
 /* ---------------------------------------------------------------------- */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateEstimator(/*out*/ StringFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_CreateEstimator(/*out*/ StringFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3334,7 +3334,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateEstimator(/*out*/ St
         pEstimator->begin_training();
 
         size_t index(g_pointerTable.Add(pEstimator));
-        *ppHandle = reinterpret_cast<StringFeaturizer_double_t_EstimatorHandle*>(index);
+        *ppHandle = reinterpret_cast<StringFeaturizer_double_EstimatorHandle*>(index);
 
 
     
@@ -3346,7 +3346,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateEstimator(/*out*/ St
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_DestroyEstimator(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_DestroyEstimator(/*in*/ StringFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3369,7 +3369,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_DestroyEstimator(/*in*/ St
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_GetState(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_GetState(/*in*/ StringFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3391,7 +3391,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_GetState(/*in*/ StringFeat
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_IsTrainingComplete(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_IsTrainingComplete(/*in*/ StringFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3413,7 +3413,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_IsTrainingComplete(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_Fit(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_Fit(/*in*/ StringFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3439,7 +3439,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_Fit(/*in*/ StringFeaturize
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_FitBuffer(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_FitBuffer(/*in*/ StringFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3466,7 +3466,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_FitBuffer(/*in*/ StringFea
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_OnDataCompleted(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_OnDataCompleted(/*in*/ StringFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3487,7 +3487,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_OnDataCompleted(/*in*/ Str
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CompleteTraining(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_CompleteTraining(/*in*/ StringFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3508,7 +3508,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CompleteTraining(/*in*/ St
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3526,7 +3526,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateTransformerFromEstim
 
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3536,7 +3536,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateTransformerFromEstim
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3552,7 +3552,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateTransformerFromSaved
         Microsoft::Featurizer::Featurizers::StringEstimator<std::double_t>::TransformerType* pTransformer(new Microsoft::Featurizer::Featurizers::StringEstimator<std::double_t>::TransformerType(archive));
 
         size_t index = g_pointerTable.Add(pTransformer);
-        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_double_t_TransformerHandle*>(index);
+        *ppTransformerHandle = reinterpret_cast<StringFeaturizer_double_TransformerHandle*>(index);
     
         return true;
     }
@@ -3562,7 +3562,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateTransformerFromSaved
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_DestroyTransformer(/*in*/ StringFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_DestroyTransformer(/*in*/ StringFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3586,7 +3586,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_DestroyTransformer(/*in*/ 
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_CreateTransformerSaveData(/*in*/ StringFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3619,7 +3619,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateTransformerSaveData(
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_Transform(/*in*/ StringFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_Transform(/*in*/ StringFeaturizer_double_TransformerHandle *pHandle, /*in*/ double input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 
@@ -3661,7 +3661,7 @@ FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_Transform(/*in*/ StringFea
     }
 }
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;
 

--- a/src/SharedLibrary/GeneratedCode/SharedLibrary_StringFeaturizer.h
+++ b/src/SharedLibrary/GeneratedCode/SharedLibrary_StringFeaturizer.h
@@ -9,264 +9,264 @@
 extern "C" {
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <int8_t> */
-struct StringFeaturizer_int8_t_EstimatorHandle {};
-struct StringFeaturizer_int8_t_TransformerHandle {};
+/* |  StringFeaturizer <int8> */
+struct StringFeaturizer_int8_EstimatorHandle {};
+struct StringFeaturizer_int8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateEstimator(/*out*/ StringFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_DestroyEstimator(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_CreateEstimator(/*out*/ StringFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_DestroyEstimator(/*in*/ StringFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_GetState(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_IsTrainingComplete(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_Fit(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_FitBuffer(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_OnDataCompleted(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CompleteTraining(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_GetState(/*in*/ StringFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_IsTrainingComplete(/*in*/ StringFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_Fit(/*in*/ StringFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_FitBuffer(/*in*/ StringFeaturizer_int8_EstimatorHandle *pHandle, /*in*/ int8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_OnDataCompleted(/*in*/ StringFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_CompleteTraining(/*in*/ StringFeaturizer_int8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_DestroyTransformer(/*in*/ StringFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int8_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_DestroyTransformer(/*in*/ StringFeaturizer_int8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_int8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_CreateTransformerSaveData(/*in*/ StringFeaturizer_int8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_Transform(/*in*/ StringFeaturizer_int8_t_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_Transform(/*in*/ StringFeaturizer_int8_TransformerHandle *pHandle, /*in*/ int8_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int8_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <int16_t> */
-struct StringFeaturizer_int16_t_EstimatorHandle {};
-struct StringFeaturizer_int16_t_TransformerHandle {};
+/* |  StringFeaturizer <int16> */
+struct StringFeaturizer_int16_EstimatorHandle {};
+struct StringFeaturizer_int16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateEstimator(/*out*/ StringFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_DestroyEstimator(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_CreateEstimator(/*out*/ StringFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_DestroyEstimator(/*in*/ StringFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_GetState(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_IsTrainingComplete(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_Fit(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_FitBuffer(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_OnDataCompleted(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CompleteTraining(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_GetState(/*in*/ StringFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_IsTrainingComplete(/*in*/ StringFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_Fit(/*in*/ StringFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_FitBuffer(/*in*/ StringFeaturizer_int16_EstimatorHandle *pHandle, /*in*/ int16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_OnDataCompleted(/*in*/ StringFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_CompleteTraining(/*in*/ StringFeaturizer_int16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_DestroyTransformer(/*in*/ StringFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int16_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_DestroyTransformer(/*in*/ StringFeaturizer_int16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_int16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_CreateTransformerSaveData(/*in*/ StringFeaturizer_int16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_Transform(/*in*/ StringFeaturizer_int16_t_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_Transform(/*in*/ StringFeaturizer_int16_TransformerHandle *pHandle, /*in*/ int16_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int16_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <int32_t> */
-struct StringFeaturizer_int32_t_EstimatorHandle {};
-struct StringFeaturizer_int32_t_TransformerHandle {};
+/* |  StringFeaturizer <int32> */
+struct StringFeaturizer_int32_EstimatorHandle {};
+struct StringFeaturizer_int32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateEstimator(/*out*/ StringFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_DestroyEstimator(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_CreateEstimator(/*out*/ StringFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_DestroyEstimator(/*in*/ StringFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_GetState(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_IsTrainingComplete(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_Fit(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_FitBuffer(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_OnDataCompleted(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CompleteTraining(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_GetState(/*in*/ StringFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_IsTrainingComplete(/*in*/ StringFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_Fit(/*in*/ StringFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_FitBuffer(/*in*/ StringFeaturizer_int32_EstimatorHandle *pHandle, /*in*/ int32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_OnDataCompleted(/*in*/ StringFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_CompleteTraining(/*in*/ StringFeaturizer_int32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_DestroyTransformer(/*in*/ StringFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int32_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_DestroyTransformer(/*in*/ StringFeaturizer_int32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_int32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_CreateTransformerSaveData(/*in*/ StringFeaturizer_int32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_Transform(/*in*/ StringFeaturizer_int32_t_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_Transform(/*in*/ StringFeaturizer_int32_TransformerHandle *pHandle, /*in*/ int32_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int32_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <int64_t> */
-struct StringFeaturizer_int64_t_EstimatorHandle {};
-struct StringFeaturizer_int64_t_TransformerHandle {};
+/* |  StringFeaturizer <int64> */
+struct StringFeaturizer_int64_EstimatorHandle {};
+struct StringFeaturizer_int64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateEstimator(/*out*/ StringFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_DestroyEstimator(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_CreateEstimator(/*out*/ StringFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_DestroyEstimator(/*in*/ StringFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_GetState(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_IsTrainingComplete(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_Fit(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_FitBuffer(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_OnDataCompleted(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CompleteTraining(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_GetState(/*in*/ StringFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_IsTrainingComplete(/*in*/ StringFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_Fit(/*in*/ StringFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_FitBuffer(/*in*/ StringFeaturizer_int64_EstimatorHandle *pHandle, /*in*/ int64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_OnDataCompleted(/*in*/ StringFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_CompleteTraining(/*in*/ StringFeaturizer_int64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_DestroyTransformer(/*in*/ StringFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_int64_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_int64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_DestroyTransformer(/*in*/ StringFeaturizer_int64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_int64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_CreateTransformerSaveData(/*in*/ StringFeaturizer_int64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_Transform(/*in*/ StringFeaturizer_int64_t_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_Transform(/*in*/ StringFeaturizer_int64_TransformerHandle *pHandle, /*in*/ int64_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_int64_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <uint8_t> */
-struct StringFeaturizer_uint8_t_EstimatorHandle {};
-struct StringFeaturizer_uint8_t_TransformerHandle {};
+/* |  StringFeaturizer <uint8> */
+struct StringFeaturizer_uint8_EstimatorHandle {};
+struct StringFeaturizer_uint8_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateEstimator(/*out*/ StringFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_DestroyEstimator(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_CreateEstimator(/*out*/ StringFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_DestroyEstimator(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_GetState(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_IsTrainingComplete(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_Fit(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_FitBuffer(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_OnDataCompleted(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CompleteTraining(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_GetState(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_IsTrainingComplete(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_Fit(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_FitBuffer(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pHandle, /*in*/ uint8_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_OnDataCompleted(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_CompleteTraining(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint8_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_DestroyTransformer(/*in*/ StringFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint8_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint8_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_DestroyTransformer(/*in*/ StringFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint8_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint8_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_Transform(/*in*/ StringFeaturizer_uint8_t_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_Transform(/*in*/ StringFeaturizer_uint8_TransformerHandle *pHandle, /*in*/ uint8_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint8_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <uint16_t> */
-struct StringFeaturizer_uint16_t_EstimatorHandle {};
-struct StringFeaturizer_uint16_t_TransformerHandle {};
+/* |  StringFeaturizer <uint16> */
+struct StringFeaturizer_uint16_EstimatorHandle {};
+struct StringFeaturizer_uint16_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateEstimator(/*out*/ StringFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_DestroyEstimator(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_CreateEstimator(/*out*/ StringFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_DestroyEstimator(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_GetState(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_IsTrainingComplete(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_Fit(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_FitBuffer(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_OnDataCompleted(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CompleteTraining(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_GetState(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_IsTrainingComplete(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_Fit(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_FitBuffer(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pHandle, /*in*/ uint16_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_OnDataCompleted(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_CompleteTraining(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint16_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_DestroyTransformer(/*in*/ StringFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint16_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint16_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_DestroyTransformer(/*in*/ StringFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint16_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint16_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_Transform(/*in*/ StringFeaturizer_uint16_t_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_Transform(/*in*/ StringFeaturizer_uint16_TransformerHandle *pHandle, /*in*/ uint16_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint16_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <uint32_t> */
-struct StringFeaturizer_uint32_t_EstimatorHandle {};
-struct StringFeaturizer_uint32_t_TransformerHandle {};
+/* |  StringFeaturizer <uint32> */
+struct StringFeaturizer_uint32_EstimatorHandle {};
+struct StringFeaturizer_uint32_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateEstimator(/*out*/ StringFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_DestroyEstimator(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_CreateEstimator(/*out*/ StringFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_DestroyEstimator(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_GetState(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_IsTrainingComplete(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_Fit(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_FitBuffer(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_OnDataCompleted(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CompleteTraining(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_GetState(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_IsTrainingComplete(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_Fit(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_FitBuffer(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pHandle, /*in*/ uint32_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_OnDataCompleted(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_CompleteTraining(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint32_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_DestroyTransformer(/*in*/ StringFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint32_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint32_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_DestroyTransformer(/*in*/ StringFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint32_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint32_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_Transform(/*in*/ StringFeaturizer_uint32_t_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_Transform(/*in*/ StringFeaturizer_uint32_TransformerHandle *pHandle, /*in*/ uint32_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint32_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <uint64_t> */
-struct StringFeaturizer_uint64_t_EstimatorHandle {};
-struct StringFeaturizer_uint64_t_TransformerHandle {};
+/* |  StringFeaturizer <uint64> */
+struct StringFeaturizer_uint64_EstimatorHandle {};
+struct StringFeaturizer_uint64_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateEstimator(/*out*/ StringFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_DestroyEstimator(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_CreateEstimator(/*out*/ StringFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_DestroyEstimator(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_GetState(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_IsTrainingComplete(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_Fit(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_FitBuffer(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_OnDataCompleted(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CompleteTraining(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_GetState(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_IsTrainingComplete(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_Fit(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_FitBuffer(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pHandle, /*in*/ uint64_t const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_OnDataCompleted(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_CompleteTraining(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint64_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_DestroyTransformer(/*in*/ StringFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_uint64_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_uint64_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_DestroyTransformer(/*in*/ StringFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint64_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_CreateTransformerSaveData(/*in*/ StringFeaturizer_uint64_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_Transform(/*in*/ StringFeaturizer_uint64_t_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_Transform(/*in*/ StringFeaturizer_uint64_TransformerHandle *pHandle, /*in*/ uint64_t input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_uint64_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <float_t> */
-struct StringFeaturizer_float_t_EstimatorHandle {};
-struct StringFeaturizer_float_t_TransformerHandle {};
+/* |  StringFeaturizer <float> */
+struct StringFeaturizer_float_EstimatorHandle {};
+struct StringFeaturizer_float_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateEstimator(/*out*/ StringFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_DestroyEstimator(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_CreateEstimator(/*out*/ StringFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_DestroyEstimator(/*in*/ StringFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_GetState(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_IsTrainingComplete(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_Fit(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_FitBuffer(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_OnDataCompleted(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CompleteTraining(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_GetState(/*in*/ StringFeaturizer_float_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_IsTrainingComplete(/*in*/ StringFeaturizer_float_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_Fit(/*in*/ StringFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_FitBuffer(/*in*/ StringFeaturizer_float_EstimatorHandle *pHandle, /*in*/ float const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_OnDataCompleted(/*in*/ StringFeaturizer_float_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_CompleteTraining(/*in*/ StringFeaturizer_float_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_float_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_float_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_DestroyTransformer(/*in*/ StringFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_float_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_float_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_DestroyTransformer(/*in*/ StringFeaturizer_float_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_float_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_CreateTransformerSaveData(/*in*/ StringFeaturizer_float_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_Transform(/*in*/ StringFeaturizer_float_t_TransformerHandle *pHandle, /*in*/ float input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_float_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_Transform(/*in*/ StringFeaturizer_float_TransformerHandle *pHandle, /*in*/ float input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_float_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <double_t> */
-struct StringFeaturizer_double_t_EstimatorHandle {};
-struct StringFeaturizer_double_t_TransformerHandle {};
+/* |  StringFeaturizer <double> */
+struct StringFeaturizer_double_EstimatorHandle {};
+struct StringFeaturizer_double_TransformerHandle {};
 
 /* Training Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateEstimator(/*out*/ StringFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_DestroyEstimator(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_CreateEstimator(/*out*/ StringFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_DestroyEstimator(/*in*/ StringFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_GetState(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_IsTrainingComplete(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_Fit(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_FitBuffer(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_OnDataCompleted(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CompleteTraining(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_GetState(/*in*/ StringFeaturizer_double_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_IsTrainingComplete(/*in*/ StringFeaturizer_double_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_Fit(/*in*/ StringFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double input, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_FitBuffer(/*in*/ StringFeaturizer_double_EstimatorHandle *pHandle, /*in*/ double const * input_ptr, /*in*/ std::size_t input_items, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_OnDataCompleted(/*in*/ StringFeaturizer_double_EstimatorHandle *pHandle, /*out*/ /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_CompleteTraining(/*in*/ StringFeaturizer_double_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_double_t_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_double_t_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_DestroyTransformer(/*in*/ StringFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_CreateTransformerFromEstimator(/*in*/ StringFeaturizer_double_EstimatorHandle *pEstimatorHandle, /*out*/ StringFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_CreateTransformerFromSavedData(/*in*/ unsigned char const *pBuffer, /*in*/ std::size_t cBufferSize, /*out*/ StringFeaturizer_double_TransformerHandle **ppTransformerHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_DestroyTransformer(/*in*/ StringFeaturizer_double_TransformerHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_CreateTransformerSaveData(/*in*/ StringFeaturizer_double_t_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_CreateTransformerSaveData(/*in*/ StringFeaturizer_double_TransformerHandle *pHandle, /*out*/ unsigned char const **ppBuffer, /*out*/ std::size_t *pBufferSize, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_Transform(/*in*/ StringFeaturizer_double_t_TransformerHandle *pHandle, /*in*/ double input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool StringFeaturizer_double_t_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_Transform(/*in*/ StringFeaturizer_double_TransformerHandle *pHandle, /*in*/ double input, /*out*/ char const ** output_ptr, /*out*/ std::size_t * output_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool StringFeaturizer_double_DestroyTransformedData(/*in*/ char const *result_ptr, /*in*/ std::size_t result_items, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* ---------------------------------------------------------------------- */
 /* |  StringFeaturizer <bool> */

--- a/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_CatImputerFeaturizer.h
+++ b/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_CatImputerFeaturizer.h
@@ -8,19 +8,19 @@
 #include "Traits.h"
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <int8_t> */
+/* |  CatImputerFeaturizer <int8> */
 template <typename VectorInputT>
-void CatImputerFeaturizer_int8_t_Test(
+void CatImputerFeaturizer_int8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int8_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int8_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    CatImputerFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    CatImputerFeaturizer_int8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_int8_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int8_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -31,7 +31,7 @@ void CatImputerFeaturizer_int8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(CatImputerFeaturizer_int8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_int8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -40,7 +40,7 @@ void CatImputerFeaturizer_int8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(CatImputerFeaturizer_int8_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<int8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int8_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_int8_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::int8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int8_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -50,7 +50,7 @@ void CatImputerFeaturizer_int8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(CatImputerFeaturizer_int8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(CatImputerFeaturizer_int8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -58,7 +58,7 @@ void CatImputerFeaturizer_int8_t_Test(
         }
     }
 
-    CatImputerFeaturizer_int8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    CatImputerFeaturizer_int8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -66,31 +66,31 @@ void CatImputerFeaturizer_int8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(CatImputerFeaturizer_int8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_int8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    CatImputerFeaturizer_int8_t_TransformerHandle * pTransformerHandle(nullptr);
+    CatImputerFeaturizer_int8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_int8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(CatImputerFeaturizer_int8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int8_t> results;
+    std::vector<std::int8_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int8_t result;
+        std::int8_t result;
 
-        REQUIRE(CatImputerFeaturizer_int8_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<int8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int8_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_int8_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::int8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int8_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -107,24 +107,24 @@ void CatImputerFeaturizer_int8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(CatImputerFeaturizer_int8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <int16_t> */
+/* |  CatImputerFeaturizer <int16> */
 template <typename VectorInputT>
-void CatImputerFeaturizer_int16_t_Test(
+void CatImputerFeaturizer_int16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int16_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int16_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    CatImputerFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    CatImputerFeaturizer_int16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_int16_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int16_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -135,7 +135,7 @@ void CatImputerFeaturizer_int16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(CatImputerFeaturizer_int16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_int16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -144,7 +144,7 @@ void CatImputerFeaturizer_int16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(CatImputerFeaturizer_int16_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<int16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int16_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_int16_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::int16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int16_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -154,7 +154,7 @@ void CatImputerFeaturizer_int16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(CatImputerFeaturizer_int16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(CatImputerFeaturizer_int16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -162,7 +162,7 @@ void CatImputerFeaturizer_int16_t_Test(
         }
     }
 
-    CatImputerFeaturizer_int16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    CatImputerFeaturizer_int16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -170,31 +170,31 @@ void CatImputerFeaturizer_int16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(CatImputerFeaturizer_int16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_int16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    CatImputerFeaturizer_int16_t_TransformerHandle * pTransformerHandle(nullptr);
+    CatImputerFeaturizer_int16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_int16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(CatImputerFeaturizer_int16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int16_t> results;
+    std::vector<std::int16_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int16_t result;
+        std::int16_t result;
 
-        REQUIRE(CatImputerFeaturizer_int16_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<int16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int16_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_int16_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::int16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int16_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -211,24 +211,24 @@ void CatImputerFeaturizer_int16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(CatImputerFeaturizer_int16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <int32_t> */
+/* |  CatImputerFeaturizer <int32> */
 template <typename VectorInputT>
-void CatImputerFeaturizer_int32_t_Test(
+void CatImputerFeaturizer_int32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int32_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int32_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    CatImputerFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    CatImputerFeaturizer_int32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_int32_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int32_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -239,7 +239,7 @@ void CatImputerFeaturizer_int32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(CatImputerFeaturizer_int32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_int32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -248,7 +248,7 @@ void CatImputerFeaturizer_int32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(CatImputerFeaturizer_int32_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<int32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int32_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_int32_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::int32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int32_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -258,7 +258,7 @@ void CatImputerFeaturizer_int32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(CatImputerFeaturizer_int32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(CatImputerFeaturizer_int32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -266,7 +266,7 @@ void CatImputerFeaturizer_int32_t_Test(
         }
     }
 
-    CatImputerFeaturizer_int32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    CatImputerFeaturizer_int32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -274,31 +274,31 @@ void CatImputerFeaturizer_int32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(CatImputerFeaturizer_int32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_int32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    CatImputerFeaturizer_int32_t_TransformerHandle * pTransformerHandle(nullptr);
+    CatImputerFeaturizer_int32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_int32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(CatImputerFeaturizer_int32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int32_t> results;
+    std::vector<std::int32_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int32_t result;
+        std::int32_t result;
 
-        REQUIRE(CatImputerFeaturizer_int32_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<int32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int32_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_int32_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::int32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int32_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -315,24 +315,24 @@ void CatImputerFeaturizer_int32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(CatImputerFeaturizer_int32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <int64_t> */
+/* |  CatImputerFeaturizer <int64> */
 template <typename VectorInputT>
-void CatImputerFeaturizer_int64_t_Test(
+void CatImputerFeaturizer_int64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int64_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int64_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    CatImputerFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    CatImputerFeaturizer_int64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_int64_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int64_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -343,7 +343,7 @@ void CatImputerFeaturizer_int64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(CatImputerFeaturizer_int64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_int64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -352,7 +352,7 @@ void CatImputerFeaturizer_int64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(CatImputerFeaturizer_int64_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<int64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int64_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_int64_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::int64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int64_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -362,7 +362,7 @@ void CatImputerFeaturizer_int64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(CatImputerFeaturizer_int64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(CatImputerFeaturizer_int64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -370,7 +370,7 @@ void CatImputerFeaturizer_int64_t_Test(
         }
     }
 
-    CatImputerFeaturizer_int64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    CatImputerFeaturizer_int64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -378,31 +378,31 @@ void CatImputerFeaturizer_int64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(CatImputerFeaturizer_int64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_int64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    CatImputerFeaturizer_int64_t_TransformerHandle * pTransformerHandle(nullptr);
+    CatImputerFeaturizer_int64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_int64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(CatImputerFeaturizer_int64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int64_t> results;
+    std::vector<std::int64_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int64_t result;
+        std::int64_t result;
 
-        REQUIRE(CatImputerFeaturizer_int64_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<int64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int64_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_int64_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::int64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int64_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -419,24 +419,24 @@ void CatImputerFeaturizer_int64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(CatImputerFeaturizer_int64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_int64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <uint8_t> */
+/* |  CatImputerFeaturizer <uint8> */
 template <typename VectorInputT>
-void CatImputerFeaturizer_uint8_t_Test(
+void CatImputerFeaturizer_uint8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint8_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::uint8_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    CatImputerFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    CatImputerFeaturizer_uint8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_uint8_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint8_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -447,7 +447,7 @@ void CatImputerFeaturizer_uint8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(CatImputerFeaturizer_uint8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_uint8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -456,7 +456,7 @@ void CatImputerFeaturizer_uint8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(CatImputerFeaturizer_uint8_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<uint8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint8_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_uint8_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::uint8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint8_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -466,7 +466,7 @@ void CatImputerFeaturizer_uint8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(CatImputerFeaturizer_uint8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(CatImputerFeaturizer_uint8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -474,7 +474,7 @@ void CatImputerFeaturizer_uint8_t_Test(
         }
     }
 
-    CatImputerFeaturizer_uint8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    CatImputerFeaturizer_uint8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -482,31 +482,31 @@ void CatImputerFeaturizer_uint8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(CatImputerFeaturizer_uint8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_uint8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    CatImputerFeaturizer_uint8_t_TransformerHandle * pTransformerHandle(nullptr);
+    CatImputerFeaturizer_uint8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_uint8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(CatImputerFeaturizer_uint8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint8_t> results;
+    std::vector<std::uint8_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint8_t result;
+        std::uint8_t result;
 
-        REQUIRE(CatImputerFeaturizer_uint8_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<uint8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint8_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_uint8_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::uint8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint8_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -523,24 +523,24 @@ void CatImputerFeaturizer_uint8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(CatImputerFeaturizer_uint8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <uint16_t> */
+/* |  CatImputerFeaturizer <uint16> */
 template <typename VectorInputT>
-void CatImputerFeaturizer_uint16_t_Test(
+void CatImputerFeaturizer_uint16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint16_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::uint16_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    CatImputerFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    CatImputerFeaturizer_uint16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_uint16_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint16_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -551,7 +551,7 @@ void CatImputerFeaturizer_uint16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(CatImputerFeaturizer_uint16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_uint16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -560,7 +560,7 @@ void CatImputerFeaturizer_uint16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(CatImputerFeaturizer_uint16_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<uint16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint16_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_uint16_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::uint16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint16_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -570,7 +570,7 @@ void CatImputerFeaturizer_uint16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(CatImputerFeaturizer_uint16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(CatImputerFeaturizer_uint16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -578,7 +578,7 @@ void CatImputerFeaturizer_uint16_t_Test(
         }
     }
 
-    CatImputerFeaturizer_uint16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    CatImputerFeaturizer_uint16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -586,31 +586,31 @@ void CatImputerFeaturizer_uint16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(CatImputerFeaturizer_uint16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_uint16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    CatImputerFeaturizer_uint16_t_TransformerHandle * pTransformerHandle(nullptr);
+    CatImputerFeaturizer_uint16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_uint16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(CatImputerFeaturizer_uint16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint16_t> results;
+    std::vector<std::uint16_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint16_t result;
+        std::uint16_t result;
 
-        REQUIRE(CatImputerFeaturizer_uint16_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<uint16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint16_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_uint16_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::uint16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint16_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -627,24 +627,24 @@ void CatImputerFeaturizer_uint16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(CatImputerFeaturizer_uint16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <uint32_t> */
+/* |  CatImputerFeaturizer <uint32> */
 template <typename VectorInputT>
-void CatImputerFeaturizer_uint32_t_Test(
+void CatImputerFeaturizer_uint32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint32_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::uint32_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    CatImputerFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    CatImputerFeaturizer_uint32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_uint32_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint32_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -655,7 +655,7 @@ void CatImputerFeaturizer_uint32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(CatImputerFeaturizer_uint32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_uint32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -664,7 +664,7 @@ void CatImputerFeaturizer_uint32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(CatImputerFeaturizer_uint32_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<uint32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint32_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_uint32_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::uint32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint32_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -674,7 +674,7 @@ void CatImputerFeaturizer_uint32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(CatImputerFeaturizer_uint32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(CatImputerFeaturizer_uint32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -682,7 +682,7 @@ void CatImputerFeaturizer_uint32_t_Test(
         }
     }
 
-    CatImputerFeaturizer_uint32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    CatImputerFeaturizer_uint32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -690,31 +690,31 @@ void CatImputerFeaturizer_uint32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(CatImputerFeaturizer_uint32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_uint32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    CatImputerFeaturizer_uint32_t_TransformerHandle * pTransformerHandle(nullptr);
+    CatImputerFeaturizer_uint32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_uint32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(CatImputerFeaturizer_uint32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint32_t> results;
+    std::vector<std::uint32_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint32_t result;
+        std::uint32_t result;
 
-        REQUIRE(CatImputerFeaturizer_uint32_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<uint32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint32_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_uint32_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::uint32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint32_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -731,24 +731,24 @@ void CatImputerFeaturizer_uint32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(CatImputerFeaturizer_uint32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <uint64_t> */
+/* |  CatImputerFeaturizer <uint64> */
 template <typename VectorInputT>
-void CatImputerFeaturizer_uint64_t_Test(
+void CatImputerFeaturizer_uint64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint64_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::uint64_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    CatImputerFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    CatImputerFeaturizer_uint64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_uint64_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint64_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -759,7 +759,7 @@ void CatImputerFeaturizer_uint64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(CatImputerFeaturizer_uint64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_uint64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -768,7 +768,7 @@ void CatImputerFeaturizer_uint64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(CatImputerFeaturizer_uint64_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<uint64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint64_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_uint64_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::uint64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint64_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -778,7 +778,7 @@ void CatImputerFeaturizer_uint64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(CatImputerFeaturizer_uint64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(CatImputerFeaturizer_uint64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -786,7 +786,7 @@ void CatImputerFeaturizer_uint64_t_Test(
         }
     }
 
-    CatImputerFeaturizer_uint64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    CatImputerFeaturizer_uint64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -794,31 +794,31 @@ void CatImputerFeaturizer_uint64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(CatImputerFeaturizer_uint64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_uint64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    CatImputerFeaturizer_uint64_t_TransformerHandle * pTransformerHandle(nullptr);
+    CatImputerFeaturizer_uint64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_uint64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(CatImputerFeaturizer_uint64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint64_t> results;
+    std::vector<std::uint64_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint64_t result;
+        std::uint64_t result;
 
-        REQUIRE(CatImputerFeaturizer_uint64_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<uint64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint64_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_uint64_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::uint64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint64_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -835,24 +835,24 @@ void CatImputerFeaturizer_uint64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(CatImputerFeaturizer_uint64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_uint64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <float_t> */
+/* |  CatImputerFeaturizer <float> */
 template <typename VectorInputT>
-void CatImputerFeaturizer_float_t_Test(
+void CatImputerFeaturizer_float_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<float> const &)> const &verify_func
+    std::function<bool (std::vector<std::float_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    CatImputerFeaturizer_float_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    CatImputerFeaturizer_float_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_float_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_float_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -863,7 +863,7 @@ void CatImputerFeaturizer_float_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(CatImputerFeaturizer_float_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_float_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -872,7 +872,7 @@ void CatImputerFeaturizer_float_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(CatImputerFeaturizer_float_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<float>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<float>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_float_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::float_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::float_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -882,7 +882,7 @@ void CatImputerFeaturizer_float_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(CatImputerFeaturizer_float_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(CatImputerFeaturizer_float_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -890,7 +890,7 @@ void CatImputerFeaturizer_float_t_Test(
         }
     }
 
-    CatImputerFeaturizer_float_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    CatImputerFeaturizer_float_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -898,31 +898,31 @@ void CatImputerFeaturizer_float_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(CatImputerFeaturizer_float_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_float_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    CatImputerFeaturizer_float_t_TransformerHandle * pTransformerHandle(nullptr);
+    CatImputerFeaturizer_float_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_float_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_float_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(CatImputerFeaturizer_float_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_float_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<float> results;
+    std::vector<std::float_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        float result;
+        std::float_t result;
 
-        REQUIRE(CatImputerFeaturizer_float_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<float>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<float>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_float_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::float_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::float_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -939,24 +939,24 @@ void CatImputerFeaturizer_float_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(CatImputerFeaturizer_float_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_float_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  CatImputerFeaturizer <double_t> */
+/* |  CatImputerFeaturizer <double> */
 template <typename VectorInputT>
-void CatImputerFeaturizer_double_t_Test(
+void CatImputerFeaturizer_double_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    CatImputerFeaturizer_double_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    CatImputerFeaturizer_double_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_double_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_double_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -967,7 +967,7 @@ void CatImputerFeaturizer_double_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(CatImputerFeaturizer_double_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_double_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -976,7 +976,7 @@ void CatImputerFeaturizer_double_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(CatImputerFeaturizer_double_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<double>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<double>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(CatImputerFeaturizer_double_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::double_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::double_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -986,7 +986,7 @@ void CatImputerFeaturizer_double_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(CatImputerFeaturizer_double_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(CatImputerFeaturizer_double_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -994,7 +994,7 @@ void CatImputerFeaturizer_double_t_Test(
         }
     }
 
-    CatImputerFeaturizer_double_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    CatImputerFeaturizer_double_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -1002,31 +1002,31 @@ void CatImputerFeaturizer_double_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(CatImputerFeaturizer_double_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_double_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    CatImputerFeaturizer_double_t_TransformerHandle * pTransformerHandle(nullptr);
+    CatImputerFeaturizer_double_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(CatImputerFeaturizer_double_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_double_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(CatImputerFeaturizer_double_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_double_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(CatImputerFeaturizer_double_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<double>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<double>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(CatImputerFeaturizer_double_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::double_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::double_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -1043,7 +1043,7 @@ void CatImputerFeaturizer_double_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(CatImputerFeaturizer_double_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(CatImputerFeaturizer_double_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 

--- a/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_HashOneHotVectorizerFeaturizer.h
+++ b/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_HashOneHotVectorizerFeaturizer.h
@@ -8,9 +8,9 @@
 #include "Traits.h"
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <int8_t> */
+/* |  HashOneHotVectorizerFeaturizer <int8> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void HashOneHotVectorizerFeaturizer_int8_t_Test(
+void HashOneHotVectorizerFeaturizer_int8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<HashOneHotVectorizerStruct> const &)> const &verify_func,
@@ -19,9 +19,9 @@ void HashOneHotVectorizerFeaturizer_int8_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    HashOneHotVectorizerFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_int8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_int8_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int8_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -32,7 +32,7 @@ void HashOneHotVectorizerFeaturizer_int8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_int8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_int8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -41,7 +41,7 @@ void HashOneHotVectorizerFeaturizer_int8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_int8_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_int8_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -51,7 +51,7 @@ void HashOneHotVectorizerFeaturizer_int8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(HashOneHotVectorizerFeaturizer_int8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(HashOneHotVectorizerFeaturizer_int8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -59,7 +59,7 @@ void HashOneHotVectorizerFeaturizer_int8_t_Test(
         }
     }
 
-    HashOneHotVectorizerFeaturizer_int8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    HashOneHotVectorizerFeaturizer_int8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -67,20 +67,20 @@ void HashOneHotVectorizerFeaturizer_int8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_int8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_int8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    HashOneHotVectorizerFeaturizer_int8_t_TransformerHandle * pTransformerHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_int8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_int8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(HashOneHotVectorizerFeaturizer_int8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -91,7 +91,7 @@ void HashOneHotVectorizerFeaturizer_int8_t_Test(
     for(auto const & input : inference_input) {
         HashOneHotVectorizerStruct result;
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_int8_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_int8_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -106,19 +106,19 @@ void HashOneHotVectorizerFeaturizer_int8_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(HashOneHotVectorizerFeaturizer_int8_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_int8_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(HashOneHotVectorizerFeaturizer_int8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <int16_t> */
+/* |  HashOneHotVectorizerFeaturizer <int16> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void HashOneHotVectorizerFeaturizer_int16_t_Test(
+void HashOneHotVectorizerFeaturizer_int16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<HashOneHotVectorizerStruct> const &)> const &verify_func,
@@ -127,9 +127,9 @@ void HashOneHotVectorizerFeaturizer_int16_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    HashOneHotVectorizerFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_int16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_int16_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int16_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -140,7 +140,7 @@ void HashOneHotVectorizerFeaturizer_int16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_int16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_int16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -149,7 +149,7 @@ void HashOneHotVectorizerFeaturizer_int16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_int16_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_int16_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -159,7 +159,7 @@ void HashOneHotVectorizerFeaturizer_int16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(HashOneHotVectorizerFeaturizer_int16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(HashOneHotVectorizerFeaturizer_int16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -167,7 +167,7 @@ void HashOneHotVectorizerFeaturizer_int16_t_Test(
         }
     }
 
-    HashOneHotVectorizerFeaturizer_int16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    HashOneHotVectorizerFeaturizer_int16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -175,20 +175,20 @@ void HashOneHotVectorizerFeaturizer_int16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_int16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_int16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    HashOneHotVectorizerFeaturizer_int16_t_TransformerHandle * pTransformerHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_int16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_int16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(HashOneHotVectorizerFeaturizer_int16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -199,7 +199,7 @@ void HashOneHotVectorizerFeaturizer_int16_t_Test(
     for(auto const & input : inference_input) {
         HashOneHotVectorizerStruct result;
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_int16_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_int16_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -214,19 +214,19 @@ void HashOneHotVectorizerFeaturizer_int16_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(HashOneHotVectorizerFeaturizer_int16_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_int16_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(HashOneHotVectorizerFeaturizer_int16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <int32_t> */
+/* |  HashOneHotVectorizerFeaturizer <int32> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void HashOneHotVectorizerFeaturizer_int32_t_Test(
+void HashOneHotVectorizerFeaturizer_int32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<HashOneHotVectorizerStruct> const &)> const &verify_func,
@@ -235,9 +235,9 @@ void HashOneHotVectorizerFeaturizer_int32_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    HashOneHotVectorizerFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_int32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_int32_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int32_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -248,7 +248,7 @@ void HashOneHotVectorizerFeaturizer_int32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_int32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_int32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -257,7 +257,7 @@ void HashOneHotVectorizerFeaturizer_int32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_int32_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_int32_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -267,7 +267,7 @@ void HashOneHotVectorizerFeaturizer_int32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(HashOneHotVectorizerFeaturizer_int32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(HashOneHotVectorizerFeaturizer_int32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -275,7 +275,7 @@ void HashOneHotVectorizerFeaturizer_int32_t_Test(
         }
     }
 
-    HashOneHotVectorizerFeaturizer_int32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    HashOneHotVectorizerFeaturizer_int32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -283,20 +283,20 @@ void HashOneHotVectorizerFeaturizer_int32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_int32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_int32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    HashOneHotVectorizerFeaturizer_int32_t_TransformerHandle * pTransformerHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_int32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_int32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(HashOneHotVectorizerFeaturizer_int32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -307,7 +307,7 @@ void HashOneHotVectorizerFeaturizer_int32_t_Test(
     for(auto const & input : inference_input) {
         HashOneHotVectorizerStruct result;
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_int32_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_int32_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -322,19 +322,19 @@ void HashOneHotVectorizerFeaturizer_int32_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(HashOneHotVectorizerFeaturizer_int32_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_int32_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(HashOneHotVectorizerFeaturizer_int32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <int64_t> */
+/* |  HashOneHotVectorizerFeaturizer <int64> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void HashOneHotVectorizerFeaturizer_int64_t_Test(
+void HashOneHotVectorizerFeaturizer_int64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<HashOneHotVectorizerStruct> const &)> const &verify_func,
@@ -343,9 +343,9 @@ void HashOneHotVectorizerFeaturizer_int64_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    HashOneHotVectorizerFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_int64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_int64_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int64_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -356,7 +356,7 @@ void HashOneHotVectorizerFeaturizer_int64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_int64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_int64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -365,7 +365,7 @@ void HashOneHotVectorizerFeaturizer_int64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_int64_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_int64_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -375,7 +375,7 @@ void HashOneHotVectorizerFeaturizer_int64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(HashOneHotVectorizerFeaturizer_int64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(HashOneHotVectorizerFeaturizer_int64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -383,7 +383,7 @@ void HashOneHotVectorizerFeaturizer_int64_t_Test(
         }
     }
 
-    HashOneHotVectorizerFeaturizer_int64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    HashOneHotVectorizerFeaturizer_int64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -391,20 +391,20 @@ void HashOneHotVectorizerFeaturizer_int64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_int64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_int64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    HashOneHotVectorizerFeaturizer_int64_t_TransformerHandle * pTransformerHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_int64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_int64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(HashOneHotVectorizerFeaturizer_int64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -415,7 +415,7 @@ void HashOneHotVectorizerFeaturizer_int64_t_Test(
     for(auto const & input : inference_input) {
         HashOneHotVectorizerStruct result;
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_int64_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_int64_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -430,19 +430,19 @@ void HashOneHotVectorizerFeaturizer_int64_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(HashOneHotVectorizerFeaturizer_int64_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_int64_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(HashOneHotVectorizerFeaturizer_int64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_int64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <uint8_t> */
+/* |  HashOneHotVectorizerFeaturizer <uint8> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void HashOneHotVectorizerFeaturizer_uint8_t_Test(
+void HashOneHotVectorizerFeaturizer_uint8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<HashOneHotVectorizerStruct> const &)> const &verify_func,
@@ -451,9 +451,9 @@ void HashOneHotVectorizerFeaturizer_uint8_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    HashOneHotVectorizerFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_uint8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint8_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint8_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -464,7 +464,7 @@ void HashOneHotVectorizerFeaturizer_uint8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_uint8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_uint8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -473,7 +473,7 @@ void HashOneHotVectorizerFeaturizer_uint8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_uint8_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_uint8_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -483,7 +483,7 @@ void HashOneHotVectorizerFeaturizer_uint8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(HashOneHotVectorizerFeaturizer_uint8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(HashOneHotVectorizerFeaturizer_uint8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -491,7 +491,7 @@ void HashOneHotVectorizerFeaturizer_uint8_t_Test(
         }
     }
 
-    HashOneHotVectorizerFeaturizer_uint8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    HashOneHotVectorizerFeaturizer_uint8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -499,20 +499,20 @@ void HashOneHotVectorizerFeaturizer_uint8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_uint8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_uint8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    HashOneHotVectorizerFeaturizer_uint8_t_TransformerHandle * pTransformerHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_uint8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -523,7 +523,7 @@ void HashOneHotVectorizerFeaturizer_uint8_t_Test(
     for(auto const & input : inference_input) {
         HashOneHotVectorizerStruct result;
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_uint8_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_uint8_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -538,19 +538,19 @@ void HashOneHotVectorizerFeaturizer_uint8_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(HashOneHotVectorizerFeaturizer_uint8_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_uint8_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <uint16_t> */
+/* |  HashOneHotVectorizerFeaturizer <uint16> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void HashOneHotVectorizerFeaturizer_uint16_t_Test(
+void HashOneHotVectorizerFeaturizer_uint16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<HashOneHotVectorizerStruct> const &)> const &verify_func,
@@ -559,9 +559,9 @@ void HashOneHotVectorizerFeaturizer_uint16_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    HashOneHotVectorizerFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_uint16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint16_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint16_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -572,7 +572,7 @@ void HashOneHotVectorizerFeaturizer_uint16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_uint16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_uint16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -581,7 +581,7 @@ void HashOneHotVectorizerFeaturizer_uint16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_uint16_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_uint16_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -591,7 +591,7 @@ void HashOneHotVectorizerFeaturizer_uint16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(HashOneHotVectorizerFeaturizer_uint16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(HashOneHotVectorizerFeaturizer_uint16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -599,7 +599,7 @@ void HashOneHotVectorizerFeaturizer_uint16_t_Test(
         }
     }
 
-    HashOneHotVectorizerFeaturizer_uint16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    HashOneHotVectorizerFeaturizer_uint16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -607,20 +607,20 @@ void HashOneHotVectorizerFeaturizer_uint16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_uint16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_uint16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    HashOneHotVectorizerFeaturizer_uint16_t_TransformerHandle * pTransformerHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_uint16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -631,7 +631,7 @@ void HashOneHotVectorizerFeaturizer_uint16_t_Test(
     for(auto const & input : inference_input) {
         HashOneHotVectorizerStruct result;
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_uint16_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_uint16_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -646,19 +646,19 @@ void HashOneHotVectorizerFeaturizer_uint16_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(HashOneHotVectorizerFeaturizer_uint16_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_uint16_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <uint32_t> */
+/* |  HashOneHotVectorizerFeaturizer <uint32> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void HashOneHotVectorizerFeaturizer_uint32_t_Test(
+void HashOneHotVectorizerFeaturizer_uint32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<HashOneHotVectorizerStruct> const &)> const &verify_func,
@@ -667,9 +667,9 @@ void HashOneHotVectorizerFeaturizer_uint32_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    HashOneHotVectorizerFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_uint32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint32_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint32_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -680,7 +680,7 @@ void HashOneHotVectorizerFeaturizer_uint32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_uint32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_uint32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -689,7 +689,7 @@ void HashOneHotVectorizerFeaturizer_uint32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_uint32_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_uint32_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -699,7 +699,7 @@ void HashOneHotVectorizerFeaturizer_uint32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(HashOneHotVectorizerFeaturizer_uint32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(HashOneHotVectorizerFeaturizer_uint32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -707,7 +707,7 @@ void HashOneHotVectorizerFeaturizer_uint32_t_Test(
         }
     }
 
-    HashOneHotVectorizerFeaturizer_uint32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    HashOneHotVectorizerFeaturizer_uint32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -715,20 +715,20 @@ void HashOneHotVectorizerFeaturizer_uint32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_uint32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_uint32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    HashOneHotVectorizerFeaturizer_uint32_t_TransformerHandle * pTransformerHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_uint32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -739,7 +739,7 @@ void HashOneHotVectorizerFeaturizer_uint32_t_Test(
     for(auto const & input : inference_input) {
         HashOneHotVectorizerStruct result;
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_uint32_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_uint32_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -754,19 +754,19 @@ void HashOneHotVectorizerFeaturizer_uint32_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(HashOneHotVectorizerFeaturizer_uint32_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_uint32_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <uint64_t> */
+/* |  HashOneHotVectorizerFeaturizer <uint64> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void HashOneHotVectorizerFeaturizer_uint64_t_Test(
+void HashOneHotVectorizerFeaturizer_uint64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<HashOneHotVectorizerStruct> const &)> const &verify_func,
@@ -775,9 +775,9 @@ void HashOneHotVectorizerFeaturizer_uint64_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    HashOneHotVectorizerFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_uint64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint64_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint64_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -788,7 +788,7 @@ void HashOneHotVectorizerFeaturizer_uint64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_uint64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_uint64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -797,7 +797,7 @@ void HashOneHotVectorizerFeaturizer_uint64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_uint64_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_uint64_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -807,7 +807,7 @@ void HashOneHotVectorizerFeaturizer_uint64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(HashOneHotVectorizerFeaturizer_uint64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(HashOneHotVectorizerFeaturizer_uint64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -815,7 +815,7 @@ void HashOneHotVectorizerFeaturizer_uint64_t_Test(
         }
     }
 
-    HashOneHotVectorizerFeaturizer_uint64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    HashOneHotVectorizerFeaturizer_uint64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -823,20 +823,20 @@ void HashOneHotVectorizerFeaturizer_uint64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_uint64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_uint64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    HashOneHotVectorizerFeaturizer_uint64_t_TransformerHandle * pTransformerHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_uint64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -847,7 +847,7 @@ void HashOneHotVectorizerFeaturizer_uint64_t_Test(
     for(auto const & input : inference_input) {
         HashOneHotVectorizerStruct result;
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_uint64_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_uint64_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -862,19 +862,19 @@ void HashOneHotVectorizerFeaturizer_uint64_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(HashOneHotVectorizerFeaturizer_uint64_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_uint64_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(HashOneHotVectorizerFeaturizer_uint64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_uint64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <float_t> */
+/* |  HashOneHotVectorizerFeaturizer <float> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void HashOneHotVectorizerFeaturizer_float_t_Test(
+void HashOneHotVectorizerFeaturizer_float_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<HashOneHotVectorizerStruct> const &)> const &verify_func,
@@ -883,9 +883,9 @@ void HashOneHotVectorizerFeaturizer_float_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    HashOneHotVectorizerFeaturizer_float_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_float_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_float_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_float_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -896,7 +896,7 @@ void HashOneHotVectorizerFeaturizer_float_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_float_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_float_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -905,7 +905,7 @@ void HashOneHotVectorizerFeaturizer_float_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_float_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_float_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -915,7 +915,7 @@ void HashOneHotVectorizerFeaturizer_float_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(HashOneHotVectorizerFeaturizer_float_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(HashOneHotVectorizerFeaturizer_float_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -923,7 +923,7 @@ void HashOneHotVectorizerFeaturizer_float_t_Test(
         }
     }
 
-    HashOneHotVectorizerFeaturizer_float_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    HashOneHotVectorizerFeaturizer_float_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -931,20 +931,20 @@ void HashOneHotVectorizerFeaturizer_float_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_float_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_float_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    HashOneHotVectorizerFeaturizer_float_t_TransformerHandle * pTransformerHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_float_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_float_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_float_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(HashOneHotVectorizerFeaturizer_float_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_float_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -955,7 +955,7 @@ void HashOneHotVectorizerFeaturizer_float_t_Test(
     for(auto const & input : inference_input) {
         HashOneHotVectorizerStruct result;
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_float_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_float_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -970,19 +970,19 @@ void HashOneHotVectorizerFeaturizer_float_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(HashOneHotVectorizerFeaturizer_float_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_float_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(HashOneHotVectorizerFeaturizer_float_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_float_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  HashOneHotVectorizerFeaturizer <double_t> */
+/* |  HashOneHotVectorizerFeaturizer <double> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void HashOneHotVectorizerFeaturizer_double_t_Test(
+void HashOneHotVectorizerFeaturizer_double_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<HashOneHotVectorizerStruct> const &)> const &verify_func,
@@ -991,9 +991,9 @@ void HashOneHotVectorizerFeaturizer_double_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    HashOneHotVectorizerFeaturizer_double_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_double_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_double_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_double_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -1004,7 +1004,7 @@ void HashOneHotVectorizerFeaturizer_double_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_double_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_double_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -1013,7 +1013,7 @@ void HashOneHotVectorizerFeaturizer_double_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(HashOneHotVectorizerFeaturizer_double_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(HashOneHotVectorizerFeaturizer_double_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -1023,7 +1023,7 @@ void HashOneHotVectorizerFeaturizer_double_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(HashOneHotVectorizerFeaturizer_double_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(HashOneHotVectorizerFeaturizer_double_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -1031,7 +1031,7 @@ void HashOneHotVectorizerFeaturizer_double_t_Test(
         }
     }
 
-    HashOneHotVectorizerFeaturizer_double_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    HashOneHotVectorizerFeaturizer_double_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -1039,20 +1039,20 @@ void HashOneHotVectorizerFeaturizer_double_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_double_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_double_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    HashOneHotVectorizerFeaturizer_double_t_TransformerHandle * pTransformerHandle(nullptr);
+    HashOneHotVectorizerFeaturizer_double_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(HashOneHotVectorizerFeaturizer_double_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_double_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(HashOneHotVectorizerFeaturizer_double_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_double_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -1063,7 +1063,7 @@ void HashOneHotVectorizerFeaturizer_double_t_Test(
     for(auto const & input : inference_input) {
         HashOneHotVectorizerStruct result;
 
-        REQUIRE(HashOneHotVectorizerFeaturizer_double_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_double_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -1078,12 +1078,12 @@ void HashOneHotVectorizerFeaturizer_double_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(HashOneHotVectorizerFeaturizer_double_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(HashOneHotVectorizerFeaturizer_double_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(HashOneHotVectorizerFeaturizer_double_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(HashOneHotVectorizerFeaturizer_double_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 

--- a/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_ImputationMarkerFeaturizer.h
+++ b/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_ImputationMarkerFeaturizer.h
@@ -8,9 +8,9 @@
 #include "Traits.h"
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <int8_t> */
+/* |  ImputationMarkerFeaturizer <int8> */
 template <typename VectorInputT>
-void ImputationMarkerFeaturizer_int8_t_Test(
+void ImputationMarkerFeaturizer_int8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<bool> const &)> const &verify_func
@@ -18,9 +18,9 @@ void ImputationMarkerFeaturizer_int8_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    ImputationMarkerFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    ImputationMarkerFeaturizer_int8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_int8_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int8_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -31,7 +31,7 @@ void ImputationMarkerFeaturizer_int8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(ImputationMarkerFeaturizer_int8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_int8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -40,7 +40,7 @@ void ImputationMarkerFeaturizer_int8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(ImputationMarkerFeaturizer_int8_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<int8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int8_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_int8_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::int8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int8_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -50,7 +50,7 @@ void ImputationMarkerFeaturizer_int8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(ImputationMarkerFeaturizer_int8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(ImputationMarkerFeaturizer_int8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -58,7 +58,7 @@ void ImputationMarkerFeaturizer_int8_t_Test(
         }
     }
 
-    ImputationMarkerFeaturizer_int8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    ImputationMarkerFeaturizer_int8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -66,20 +66,20 @@ void ImputationMarkerFeaturizer_int8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(ImputationMarkerFeaturizer_int8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_int8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    ImputationMarkerFeaturizer_int8_t_TransformerHandle * pTransformerHandle(nullptr);
+    ImputationMarkerFeaturizer_int8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_int8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(ImputationMarkerFeaturizer_int8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -90,7 +90,7 @@ void ImputationMarkerFeaturizer_int8_t_Test(
     for(auto const & input : inference_input) {
         bool result;
 
-        REQUIRE(ImputationMarkerFeaturizer_int8_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<int8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int8_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_int8_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::int8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int8_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -107,14 +107,14 @@ void ImputationMarkerFeaturizer_int8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(ImputationMarkerFeaturizer_int8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <int16_t> */
+/* |  ImputationMarkerFeaturizer <int16> */
 template <typename VectorInputT>
-void ImputationMarkerFeaturizer_int16_t_Test(
+void ImputationMarkerFeaturizer_int16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<bool> const &)> const &verify_func
@@ -122,9 +122,9 @@ void ImputationMarkerFeaturizer_int16_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    ImputationMarkerFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    ImputationMarkerFeaturizer_int16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_int16_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int16_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -135,7 +135,7 @@ void ImputationMarkerFeaturizer_int16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(ImputationMarkerFeaturizer_int16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_int16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -144,7 +144,7 @@ void ImputationMarkerFeaturizer_int16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(ImputationMarkerFeaturizer_int16_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<int16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int16_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_int16_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::int16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int16_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -154,7 +154,7 @@ void ImputationMarkerFeaturizer_int16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(ImputationMarkerFeaturizer_int16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(ImputationMarkerFeaturizer_int16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -162,7 +162,7 @@ void ImputationMarkerFeaturizer_int16_t_Test(
         }
     }
 
-    ImputationMarkerFeaturizer_int16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    ImputationMarkerFeaturizer_int16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -170,20 +170,20 @@ void ImputationMarkerFeaturizer_int16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(ImputationMarkerFeaturizer_int16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_int16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    ImputationMarkerFeaturizer_int16_t_TransformerHandle * pTransformerHandle(nullptr);
+    ImputationMarkerFeaturizer_int16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_int16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(ImputationMarkerFeaturizer_int16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -194,7 +194,7 @@ void ImputationMarkerFeaturizer_int16_t_Test(
     for(auto const & input : inference_input) {
         bool result;
 
-        REQUIRE(ImputationMarkerFeaturizer_int16_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<int16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int16_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_int16_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::int16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int16_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -211,14 +211,14 @@ void ImputationMarkerFeaturizer_int16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(ImputationMarkerFeaturizer_int16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <int32_t> */
+/* |  ImputationMarkerFeaturizer <int32> */
 template <typename VectorInputT>
-void ImputationMarkerFeaturizer_int32_t_Test(
+void ImputationMarkerFeaturizer_int32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<bool> const &)> const &verify_func
@@ -226,9 +226,9 @@ void ImputationMarkerFeaturizer_int32_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    ImputationMarkerFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    ImputationMarkerFeaturizer_int32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_int32_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int32_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -239,7 +239,7 @@ void ImputationMarkerFeaturizer_int32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(ImputationMarkerFeaturizer_int32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_int32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -248,7 +248,7 @@ void ImputationMarkerFeaturizer_int32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(ImputationMarkerFeaturizer_int32_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<int32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int32_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_int32_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::int32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int32_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -258,7 +258,7 @@ void ImputationMarkerFeaturizer_int32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(ImputationMarkerFeaturizer_int32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(ImputationMarkerFeaturizer_int32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -266,7 +266,7 @@ void ImputationMarkerFeaturizer_int32_t_Test(
         }
     }
 
-    ImputationMarkerFeaturizer_int32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    ImputationMarkerFeaturizer_int32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -274,20 +274,20 @@ void ImputationMarkerFeaturizer_int32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(ImputationMarkerFeaturizer_int32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_int32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    ImputationMarkerFeaturizer_int32_t_TransformerHandle * pTransformerHandle(nullptr);
+    ImputationMarkerFeaturizer_int32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_int32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(ImputationMarkerFeaturizer_int32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -298,7 +298,7 @@ void ImputationMarkerFeaturizer_int32_t_Test(
     for(auto const & input : inference_input) {
         bool result;
 
-        REQUIRE(ImputationMarkerFeaturizer_int32_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<int32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int32_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_int32_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::int32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int32_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -315,14 +315,14 @@ void ImputationMarkerFeaturizer_int32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(ImputationMarkerFeaturizer_int32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <int64_t> */
+/* |  ImputationMarkerFeaturizer <int64> */
 template <typename VectorInputT>
-void ImputationMarkerFeaturizer_int64_t_Test(
+void ImputationMarkerFeaturizer_int64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<bool> const &)> const &verify_func
@@ -330,9 +330,9 @@ void ImputationMarkerFeaturizer_int64_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    ImputationMarkerFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    ImputationMarkerFeaturizer_int64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_int64_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int64_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -343,7 +343,7 @@ void ImputationMarkerFeaturizer_int64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(ImputationMarkerFeaturizer_int64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_int64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -352,7 +352,7 @@ void ImputationMarkerFeaturizer_int64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(ImputationMarkerFeaturizer_int64_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<int64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int64_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_int64_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::int64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int64_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -362,7 +362,7 @@ void ImputationMarkerFeaturizer_int64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(ImputationMarkerFeaturizer_int64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(ImputationMarkerFeaturizer_int64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -370,7 +370,7 @@ void ImputationMarkerFeaturizer_int64_t_Test(
         }
     }
 
-    ImputationMarkerFeaturizer_int64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    ImputationMarkerFeaturizer_int64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -378,20 +378,20 @@ void ImputationMarkerFeaturizer_int64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(ImputationMarkerFeaturizer_int64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_int64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    ImputationMarkerFeaturizer_int64_t_TransformerHandle * pTransformerHandle(nullptr);
+    ImputationMarkerFeaturizer_int64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_int64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(ImputationMarkerFeaturizer_int64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -402,7 +402,7 @@ void ImputationMarkerFeaturizer_int64_t_Test(
     for(auto const & input : inference_input) {
         bool result;
 
-        REQUIRE(ImputationMarkerFeaturizer_int64_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<int64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int64_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_int64_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::int64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int64_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -419,14 +419,14 @@ void ImputationMarkerFeaturizer_int64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(ImputationMarkerFeaturizer_int64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_int64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <uint8_t> */
+/* |  ImputationMarkerFeaturizer <uint8> */
 template <typename VectorInputT>
-void ImputationMarkerFeaturizer_uint8_t_Test(
+void ImputationMarkerFeaturizer_uint8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<bool> const &)> const &verify_func
@@ -434,9 +434,9 @@ void ImputationMarkerFeaturizer_uint8_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    ImputationMarkerFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    ImputationMarkerFeaturizer_uint8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_uint8_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint8_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -447,7 +447,7 @@ void ImputationMarkerFeaturizer_uint8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(ImputationMarkerFeaturizer_uint8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_uint8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -456,7 +456,7 @@ void ImputationMarkerFeaturizer_uint8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(ImputationMarkerFeaturizer_uint8_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<uint8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint8_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_uint8_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::uint8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint8_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -466,7 +466,7 @@ void ImputationMarkerFeaturizer_uint8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(ImputationMarkerFeaturizer_uint8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(ImputationMarkerFeaturizer_uint8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -474,7 +474,7 @@ void ImputationMarkerFeaturizer_uint8_t_Test(
         }
     }
 
-    ImputationMarkerFeaturizer_uint8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    ImputationMarkerFeaturizer_uint8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -482,20 +482,20 @@ void ImputationMarkerFeaturizer_uint8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(ImputationMarkerFeaturizer_uint8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_uint8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    ImputationMarkerFeaturizer_uint8_t_TransformerHandle * pTransformerHandle(nullptr);
+    ImputationMarkerFeaturizer_uint8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_uint8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(ImputationMarkerFeaturizer_uint8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -506,7 +506,7 @@ void ImputationMarkerFeaturizer_uint8_t_Test(
     for(auto const & input : inference_input) {
         bool result;
 
-        REQUIRE(ImputationMarkerFeaturizer_uint8_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<uint8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint8_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_uint8_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::uint8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint8_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -523,14 +523,14 @@ void ImputationMarkerFeaturizer_uint8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(ImputationMarkerFeaturizer_uint8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <uint16_t> */
+/* |  ImputationMarkerFeaturizer <uint16> */
 template <typename VectorInputT>
-void ImputationMarkerFeaturizer_uint16_t_Test(
+void ImputationMarkerFeaturizer_uint16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<bool> const &)> const &verify_func
@@ -538,9 +538,9 @@ void ImputationMarkerFeaturizer_uint16_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    ImputationMarkerFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    ImputationMarkerFeaturizer_uint16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_uint16_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint16_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -551,7 +551,7 @@ void ImputationMarkerFeaturizer_uint16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(ImputationMarkerFeaturizer_uint16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_uint16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -560,7 +560,7 @@ void ImputationMarkerFeaturizer_uint16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(ImputationMarkerFeaturizer_uint16_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<uint16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint16_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_uint16_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::uint16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint16_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -570,7 +570,7 @@ void ImputationMarkerFeaturizer_uint16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(ImputationMarkerFeaturizer_uint16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(ImputationMarkerFeaturizer_uint16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -578,7 +578,7 @@ void ImputationMarkerFeaturizer_uint16_t_Test(
         }
     }
 
-    ImputationMarkerFeaturizer_uint16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    ImputationMarkerFeaturizer_uint16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -586,20 +586,20 @@ void ImputationMarkerFeaturizer_uint16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(ImputationMarkerFeaturizer_uint16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_uint16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    ImputationMarkerFeaturizer_uint16_t_TransformerHandle * pTransformerHandle(nullptr);
+    ImputationMarkerFeaturizer_uint16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_uint16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(ImputationMarkerFeaturizer_uint16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -610,7 +610,7 @@ void ImputationMarkerFeaturizer_uint16_t_Test(
     for(auto const & input : inference_input) {
         bool result;
 
-        REQUIRE(ImputationMarkerFeaturizer_uint16_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<uint16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint16_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_uint16_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::uint16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint16_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -627,14 +627,14 @@ void ImputationMarkerFeaturizer_uint16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(ImputationMarkerFeaturizer_uint16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <uint32_t> */
+/* |  ImputationMarkerFeaturizer <uint32> */
 template <typename VectorInputT>
-void ImputationMarkerFeaturizer_uint32_t_Test(
+void ImputationMarkerFeaturizer_uint32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<bool> const &)> const &verify_func
@@ -642,9 +642,9 @@ void ImputationMarkerFeaturizer_uint32_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    ImputationMarkerFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    ImputationMarkerFeaturizer_uint32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_uint32_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint32_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -655,7 +655,7 @@ void ImputationMarkerFeaturizer_uint32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(ImputationMarkerFeaturizer_uint32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_uint32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -664,7 +664,7 @@ void ImputationMarkerFeaturizer_uint32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(ImputationMarkerFeaturizer_uint32_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<uint32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint32_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_uint32_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::uint32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint32_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -674,7 +674,7 @@ void ImputationMarkerFeaturizer_uint32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(ImputationMarkerFeaturizer_uint32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(ImputationMarkerFeaturizer_uint32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -682,7 +682,7 @@ void ImputationMarkerFeaturizer_uint32_t_Test(
         }
     }
 
-    ImputationMarkerFeaturizer_uint32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    ImputationMarkerFeaturizer_uint32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -690,20 +690,20 @@ void ImputationMarkerFeaturizer_uint32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(ImputationMarkerFeaturizer_uint32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_uint32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    ImputationMarkerFeaturizer_uint32_t_TransformerHandle * pTransformerHandle(nullptr);
+    ImputationMarkerFeaturizer_uint32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_uint32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(ImputationMarkerFeaturizer_uint32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -714,7 +714,7 @@ void ImputationMarkerFeaturizer_uint32_t_Test(
     for(auto const & input : inference_input) {
         bool result;
 
-        REQUIRE(ImputationMarkerFeaturizer_uint32_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<uint32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint32_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_uint32_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::uint32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint32_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -731,14 +731,14 @@ void ImputationMarkerFeaturizer_uint32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(ImputationMarkerFeaturizer_uint32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <uint64_t> */
+/* |  ImputationMarkerFeaturizer <uint64> */
 template <typename VectorInputT>
-void ImputationMarkerFeaturizer_uint64_t_Test(
+void ImputationMarkerFeaturizer_uint64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<bool> const &)> const &verify_func
@@ -746,9 +746,9 @@ void ImputationMarkerFeaturizer_uint64_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    ImputationMarkerFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    ImputationMarkerFeaturizer_uint64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_uint64_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint64_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -759,7 +759,7 @@ void ImputationMarkerFeaturizer_uint64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(ImputationMarkerFeaturizer_uint64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_uint64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -768,7 +768,7 @@ void ImputationMarkerFeaturizer_uint64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(ImputationMarkerFeaturizer_uint64_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<uint64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint64_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_uint64_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::uint64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint64_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -778,7 +778,7 @@ void ImputationMarkerFeaturizer_uint64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(ImputationMarkerFeaturizer_uint64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(ImputationMarkerFeaturizer_uint64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -786,7 +786,7 @@ void ImputationMarkerFeaturizer_uint64_t_Test(
         }
     }
 
-    ImputationMarkerFeaturizer_uint64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    ImputationMarkerFeaturizer_uint64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -794,20 +794,20 @@ void ImputationMarkerFeaturizer_uint64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(ImputationMarkerFeaturizer_uint64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_uint64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    ImputationMarkerFeaturizer_uint64_t_TransformerHandle * pTransformerHandle(nullptr);
+    ImputationMarkerFeaturizer_uint64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_uint64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(ImputationMarkerFeaturizer_uint64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -818,7 +818,7 @@ void ImputationMarkerFeaturizer_uint64_t_Test(
     for(auto const & input : inference_input) {
         bool result;
 
-        REQUIRE(ImputationMarkerFeaturizer_uint64_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<uint64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint64_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_uint64_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::uint64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint64_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -835,14 +835,14 @@ void ImputationMarkerFeaturizer_uint64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(ImputationMarkerFeaturizer_uint64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_uint64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <float_t> */
+/* |  ImputationMarkerFeaturizer <float> */
 template <typename VectorInputT>
-void ImputationMarkerFeaturizer_float_t_Test(
+void ImputationMarkerFeaturizer_float_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<bool> const &)> const &verify_func
@@ -850,9 +850,9 @@ void ImputationMarkerFeaturizer_float_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    ImputationMarkerFeaturizer_float_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    ImputationMarkerFeaturizer_float_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_float_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_float_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -863,7 +863,7 @@ void ImputationMarkerFeaturizer_float_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(ImputationMarkerFeaturizer_float_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_float_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -872,7 +872,7 @@ void ImputationMarkerFeaturizer_float_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(ImputationMarkerFeaturizer_float_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<float>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<float>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_float_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::float_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::float_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -882,7 +882,7 @@ void ImputationMarkerFeaturizer_float_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(ImputationMarkerFeaturizer_float_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(ImputationMarkerFeaturizer_float_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -890,7 +890,7 @@ void ImputationMarkerFeaturizer_float_t_Test(
         }
     }
 
-    ImputationMarkerFeaturizer_float_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    ImputationMarkerFeaturizer_float_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -898,20 +898,20 @@ void ImputationMarkerFeaturizer_float_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(ImputationMarkerFeaturizer_float_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_float_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    ImputationMarkerFeaturizer_float_t_TransformerHandle * pTransformerHandle(nullptr);
+    ImputationMarkerFeaturizer_float_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_float_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_float_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(ImputationMarkerFeaturizer_float_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_float_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -922,7 +922,7 @@ void ImputationMarkerFeaturizer_float_t_Test(
     for(auto const & input : inference_input) {
         bool result;
 
-        REQUIRE(ImputationMarkerFeaturizer_float_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<float>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<float>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_float_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::float_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::float_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -939,14 +939,14 @@ void ImputationMarkerFeaturizer_float_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(ImputationMarkerFeaturizer_float_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_float_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  ImputationMarkerFeaturizer <double_t> */
+/* |  ImputationMarkerFeaturizer <double> */
 template <typename VectorInputT>
-void ImputationMarkerFeaturizer_double_t_Test(
+void ImputationMarkerFeaturizer_double_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<bool> const &)> const &verify_func
@@ -954,9 +954,9 @@ void ImputationMarkerFeaturizer_double_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    ImputationMarkerFeaturizer_double_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    ImputationMarkerFeaturizer_double_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_double_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_double_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -967,7 +967,7 @@ void ImputationMarkerFeaturizer_double_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(ImputationMarkerFeaturizer_double_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_double_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -976,7 +976,7 @@ void ImputationMarkerFeaturizer_double_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(ImputationMarkerFeaturizer_double_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<double>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<double>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(ImputationMarkerFeaturizer_double_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::double_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::double_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -986,7 +986,7 @@ void ImputationMarkerFeaturizer_double_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(ImputationMarkerFeaturizer_double_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(ImputationMarkerFeaturizer_double_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -994,7 +994,7 @@ void ImputationMarkerFeaturizer_double_t_Test(
         }
     }
 
-    ImputationMarkerFeaturizer_double_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    ImputationMarkerFeaturizer_double_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -1002,20 +1002,20 @@ void ImputationMarkerFeaturizer_double_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(ImputationMarkerFeaturizer_double_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_double_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    ImputationMarkerFeaturizer_double_t_TransformerHandle * pTransformerHandle(nullptr);
+    ImputationMarkerFeaturizer_double_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(ImputationMarkerFeaturizer_double_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_double_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(ImputationMarkerFeaturizer_double_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_double_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -1026,7 +1026,7 @@ void ImputationMarkerFeaturizer_double_t_Test(
     for(auto const & input : inference_input) {
         bool result;
 
-        REQUIRE(ImputationMarkerFeaturizer_double_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<double>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<double>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(ImputationMarkerFeaturizer_double_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::double_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::double_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -1043,7 +1043,7 @@ void ImputationMarkerFeaturizer_double_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(ImputationMarkerFeaturizer_double_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(ImputationMarkerFeaturizer_double_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 

--- a/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_LabelEncoderFeaturizer.h
+++ b/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_LabelEncoderFeaturizer.h
@@ -8,20 +8,20 @@
 #include "Traits.h"
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <int8_t> */
+/* |  LabelEncoderFeaturizer <int8> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void LabelEncoderFeaturizer_int8_t_Test(
+void LabelEncoderFeaturizer_int8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint32_t> const &)> const &verify_func,
+    std::function<bool (std::vector<std::uint32_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    LabelEncoderFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    LabelEncoderFeaturizer_int8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_int8_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int8_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -32,7 +32,7 @@ void LabelEncoderFeaturizer_int8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(LabelEncoderFeaturizer_int8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_int8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -41,7 +41,7 @@ void LabelEncoderFeaturizer_int8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(LabelEncoderFeaturizer_int8_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_int8_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -51,7 +51,7 @@ void LabelEncoderFeaturizer_int8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(LabelEncoderFeaturizer_int8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(LabelEncoderFeaturizer_int8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -59,7 +59,7 @@ void LabelEncoderFeaturizer_int8_t_Test(
         }
     }
 
-    LabelEncoderFeaturizer_int8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    LabelEncoderFeaturizer_int8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -67,31 +67,31 @@ void LabelEncoderFeaturizer_int8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(LabelEncoderFeaturizer_int8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_int8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    LabelEncoderFeaturizer_int8_t_TransformerHandle * pTransformerHandle(nullptr);
+    LabelEncoderFeaturizer_int8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_int8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(LabelEncoderFeaturizer_int8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint32_t> results;
+    std::vector<std::uint32_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint32_t result;
+        std::uint32_t result;
 
-        REQUIRE(LabelEncoderFeaturizer_int8_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_int8_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -108,25 +108,25 @@ void LabelEncoderFeaturizer_int8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(LabelEncoderFeaturizer_int8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <int16_t> */
+/* |  LabelEncoderFeaturizer <int16> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void LabelEncoderFeaturizer_int16_t_Test(
+void LabelEncoderFeaturizer_int16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint32_t> const &)> const &verify_func,
+    std::function<bool (std::vector<std::uint32_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    LabelEncoderFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    LabelEncoderFeaturizer_int16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_int16_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int16_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -137,7 +137,7 @@ void LabelEncoderFeaturizer_int16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(LabelEncoderFeaturizer_int16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_int16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -146,7 +146,7 @@ void LabelEncoderFeaturizer_int16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(LabelEncoderFeaturizer_int16_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_int16_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -156,7 +156,7 @@ void LabelEncoderFeaturizer_int16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(LabelEncoderFeaturizer_int16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(LabelEncoderFeaturizer_int16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -164,7 +164,7 @@ void LabelEncoderFeaturizer_int16_t_Test(
         }
     }
 
-    LabelEncoderFeaturizer_int16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    LabelEncoderFeaturizer_int16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -172,31 +172,31 @@ void LabelEncoderFeaturizer_int16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(LabelEncoderFeaturizer_int16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_int16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    LabelEncoderFeaturizer_int16_t_TransformerHandle * pTransformerHandle(nullptr);
+    LabelEncoderFeaturizer_int16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_int16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(LabelEncoderFeaturizer_int16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint32_t> results;
+    std::vector<std::uint32_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint32_t result;
+        std::uint32_t result;
 
-        REQUIRE(LabelEncoderFeaturizer_int16_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_int16_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -213,25 +213,25 @@ void LabelEncoderFeaturizer_int16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(LabelEncoderFeaturizer_int16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <int32_t> */
+/* |  LabelEncoderFeaturizer <int32> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void LabelEncoderFeaturizer_int32_t_Test(
+void LabelEncoderFeaturizer_int32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint32_t> const &)> const &verify_func,
+    std::function<bool (std::vector<std::uint32_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    LabelEncoderFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    LabelEncoderFeaturizer_int32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_int32_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int32_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -242,7 +242,7 @@ void LabelEncoderFeaturizer_int32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(LabelEncoderFeaturizer_int32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_int32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -251,7 +251,7 @@ void LabelEncoderFeaturizer_int32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(LabelEncoderFeaturizer_int32_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_int32_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -261,7 +261,7 @@ void LabelEncoderFeaturizer_int32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(LabelEncoderFeaturizer_int32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(LabelEncoderFeaturizer_int32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -269,7 +269,7 @@ void LabelEncoderFeaturizer_int32_t_Test(
         }
     }
 
-    LabelEncoderFeaturizer_int32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    LabelEncoderFeaturizer_int32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -277,31 +277,31 @@ void LabelEncoderFeaturizer_int32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(LabelEncoderFeaturizer_int32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_int32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    LabelEncoderFeaturizer_int32_t_TransformerHandle * pTransformerHandle(nullptr);
+    LabelEncoderFeaturizer_int32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_int32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(LabelEncoderFeaturizer_int32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint32_t> results;
+    std::vector<std::uint32_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint32_t result;
+        std::uint32_t result;
 
-        REQUIRE(LabelEncoderFeaturizer_int32_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_int32_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -318,25 +318,25 @@ void LabelEncoderFeaturizer_int32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(LabelEncoderFeaturizer_int32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <int64_t> */
+/* |  LabelEncoderFeaturizer <int64> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void LabelEncoderFeaturizer_int64_t_Test(
+void LabelEncoderFeaturizer_int64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint32_t> const &)> const &verify_func,
+    std::function<bool (std::vector<std::uint32_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    LabelEncoderFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    LabelEncoderFeaturizer_int64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_int64_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int64_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -347,7 +347,7 @@ void LabelEncoderFeaturizer_int64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(LabelEncoderFeaturizer_int64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_int64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -356,7 +356,7 @@ void LabelEncoderFeaturizer_int64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(LabelEncoderFeaturizer_int64_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_int64_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -366,7 +366,7 @@ void LabelEncoderFeaturizer_int64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(LabelEncoderFeaturizer_int64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(LabelEncoderFeaturizer_int64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -374,7 +374,7 @@ void LabelEncoderFeaturizer_int64_t_Test(
         }
     }
 
-    LabelEncoderFeaturizer_int64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    LabelEncoderFeaturizer_int64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -382,31 +382,31 @@ void LabelEncoderFeaturizer_int64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(LabelEncoderFeaturizer_int64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_int64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    LabelEncoderFeaturizer_int64_t_TransformerHandle * pTransformerHandle(nullptr);
+    LabelEncoderFeaturizer_int64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_int64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(LabelEncoderFeaturizer_int64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint32_t> results;
+    std::vector<std::uint32_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint32_t result;
+        std::uint32_t result;
 
-        REQUIRE(LabelEncoderFeaturizer_int64_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_int64_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -423,25 +423,25 @@ void LabelEncoderFeaturizer_int64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(LabelEncoderFeaturizer_int64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_int64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <uint8_t> */
+/* |  LabelEncoderFeaturizer <uint8> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void LabelEncoderFeaturizer_uint8_t_Test(
+void LabelEncoderFeaturizer_uint8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint32_t> const &)> const &verify_func,
+    std::function<bool (std::vector<std::uint32_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    LabelEncoderFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    LabelEncoderFeaturizer_uint8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_uint8_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint8_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -452,7 +452,7 @@ void LabelEncoderFeaturizer_uint8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(LabelEncoderFeaturizer_uint8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_uint8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -461,7 +461,7 @@ void LabelEncoderFeaturizer_uint8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(LabelEncoderFeaturizer_uint8_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_uint8_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -471,7 +471,7 @@ void LabelEncoderFeaturizer_uint8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(LabelEncoderFeaturizer_uint8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(LabelEncoderFeaturizer_uint8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -479,7 +479,7 @@ void LabelEncoderFeaturizer_uint8_t_Test(
         }
     }
 
-    LabelEncoderFeaturizer_uint8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    LabelEncoderFeaturizer_uint8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -487,31 +487,31 @@ void LabelEncoderFeaturizer_uint8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(LabelEncoderFeaturizer_uint8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_uint8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    LabelEncoderFeaturizer_uint8_t_TransformerHandle * pTransformerHandle(nullptr);
+    LabelEncoderFeaturizer_uint8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_uint8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(LabelEncoderFeaturizer_uint8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint32_t> results;
+    std::vector<std::uint32_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint32_t result;
+        std::uint32_t result;
 
-        REQUIRE(LabelEncoderFeaturizer_uint8_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_uint8_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -528,25 +528,25 @@ void LabelEncoderFeaturizer_uint8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(LabelEncoderFeaturizer_uint8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <uint16_t> */
+/* |  LabelEncoderFeaturizer <uint16> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void LabelEncoderFeaturizer_uint16_t_Test(
+void LabelEncoderFeaturizer_uint16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint32_t> const &)> const &verify_func,
+    std::function<bool (std::vector<std::uint32_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    LabelEncoderFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    LabelEncoderFeaturizer_uint16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_uint16_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint16_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -557,7 +557,7 @@ void LabelEncoderFeaturizer_uint16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(LabelEncoderFeaturizer_uint16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_uint16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -566,7 +566,7 @@ void LabelEncoderFeaturizer_uint16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(LabelEncoderFeaturizer_uint16_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_uint16_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -576,7 +576,7 @@ void LabelEncoderFeaturizer_uint16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(LabelEncoderFeaturizer_uint16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(LabelEncoderFeaturizer_uint16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -584,7 +584,7 @@ void LabelEncoderFeaturizer_uint16_t_Test(
         }
     }
 
-    LabelEncoderFeaturizer_uint16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    LabelEncoderFeaturizer_uint16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -592,31 +592,31 @@ void LabelEncoderFeaturizer_uint16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(LabelEncoderFeaturizer_uint16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_uint16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    LabelEncoderFeaturizer_uint16_t_TransformerHandle * pTransformerHandle(nullptr);
+    LabelEncoderFeaturizer_uint16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_uint16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(LabelEncoderFeaturizer_uint16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint32_t> results;
+    std::vector<std::uint32_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint32_t result;
+        std::uint32_t result;
 
-        REQUIRE(LabelEncoderFeaturizer_uint16_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_uint16_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -633,25 +633,25 @@ void LabelEncoderFeaturizer_uint16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(LabelEncoderFeaturizer_uint16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <uint32_t> */
+/* |  LabelEncoderFeaturizer <uint32> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void LabelEncoderFeaturizer_uint32_t_Test(
+void LabelEncoderFeaturizer_uint32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint32_t> const &)> const &verify_func,
+    std::function<bool (std::vector<std::uint32_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    LabelEncoderFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    LabelEncoderFeaturizer_uint32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_uint32_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint32_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -662,7 +662,7 @@ void LabelEncoderFeaturizer_uint32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(LabelEncoderFeaturizer_uint32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_uint32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -671,7 +671,7 @@ void LabelEncoderFeaturizer_uint32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(LabelEncoderFeaturizer_uint32_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_uint32_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -681,7 +681,7 @@ void LabelEncoderFeaturizer_uint32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(LabelEncoderFeaturizer_uint32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(LabelEncoderFeaturizer_uint32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -689,7 +689,7 @@ void LabelEncoderFeaturizer_uint32_t_Test(
         }
     }
 
-    LabelEncoderFeaturizer_uint32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    LabelEncoderFeaturizer_uint32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -697,31 +697,31 @@ void LabelEncoderFeaturizer_uint32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(LabelEncoderFeaturizer_uint32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_uint32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    LabelEncoderFeaturizer_uint32_t_TransformerHandle * pTransformerHandle(nullptr);
+    LabelEncoderFeaturizer_uint32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_uint32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(LabelEncoderFeaturizer_uint32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint32_t> results;
+    std::vector<std::uint32_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint32_t result;
+        std::uint32_t result;
 
-        REQUIRE(LabelEncoderFeaturizer_uint32_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_uint32_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -738,25 +738,25 @@ void LabelEncoderFeaturizer_uint32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(LabelEncoderFeaturizer_uint32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <uint64_t> */
+/* |  LabelEncoderFeaturizer <uint64> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void LabelEncoderFeaturizer_uint64_t_Test(
+void LabelEncoderFeaturizer_uint64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint32_t> const &)> const &verify_func,
+    std::function<bool (std::vector<std::uint32_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    LabelEncoderFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    LabelEncoderFeaturizer_uint64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_uint64_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint64_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -767,7 +767,7 @@ void LabelEncoderFeaturizer_uint64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(LabelEncoderFeaturizer_uint64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_uint64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -776,7 +776,7 @@ void LabelEncoderFeaturizer_uint64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(LabelEncoderFeaturizer_uint64_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_uint64_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -786,7 +786,7 @@ void LabelEncoderFeaturizer_uint64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(LabelEncoderFeaturizer_uint64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(LabelEncoderFeaturizer_uint64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -794,7 +794,7 @@ void LabelEncoderFeaturizer_uint64_t_Test(
         }
     }
 
-    LabelEncoderFeaturizer_uint64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    LabelEncoderFeaturizer_uint64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -802,31 +802,31 @@ void LabelEncoderFeaturizer_uint64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(LabelEncoderFeaturizer_uint64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_uint64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    LabelEncoderFeaturizer_uint64_t_TransformerHandle * pTransformerHandle(nullptr);
+    LabelEncoderFeaturizer_uint64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_uint64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(LabelEncoderFeaturizer_uint64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint32_t> results;
+    std::vector<std::uint32_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint32_t result;
+        std::uint32_t result;
 
-        REQUIRE(LabelEncoderFeaturizer_uint64_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_uint64_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -843,25 +843,25 @@ void LabelEncoderFeaturizer_uint64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(LabelEncoderFeaturizer_uint64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_uint64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <float_t> */
+/* |  LabelEncoderFeaturizer <float> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void LabelEncoderFeaturizer_float_t_Test(
+void LabelEncoderFeaturizer_float_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint32_t> const &)> const &verify_func,
+    std::function<bool (std::vector<std::uint32_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    LabelEncoderFeaturizer_float_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    LabelEncoderFeaturizer_float_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_float_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_float_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -872,7 +872,7 @@ void LabelEncoderFeaturizer_float_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(LabelEncoderFeaturizer_float_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_float_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -881,7 +881,7 @@ void LabelEncoderFeaturizer_float_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(LabelEncoderFeaturizer_float_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_float_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -891,7 +891,7 @@ void LabelEncoderFeaturizer_float_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(LabelEncoderFeaturizer_float_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(LabelEncoderFeaturizer_float_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -899,7 +899,7 @@ void LabelEncoderFeaturizer_float_t_Test(
         }
     }
 
-    LabelEncoderFeaturizer_float_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    LabelEncoderFeaturizer_float_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -907,31 +907,31 @@ void LabelEncoderFeaturizer_float_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(LabelEncoderFeaturizer_float_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_float_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    LabelEncoderFeaturizer_float_t_TransformerHandle * pTransformerHandle(nullptr);
+    LabelEncoderFeaturizer_float_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_float_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_float_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(LabelEncoderFeaturizer_float_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_float_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint32_t> results;
+    std::vector<std::uint32_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint32_t result;
+        std::uint32_t result;
 
-        REQUIRE(LabelEncoderFeaturizer_float_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_float_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -948,25 +948,25 @@ void LabelEncoderFeaturizer_float_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(LabelEncoderFeaturizer_float_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_float_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  LabelEncoderFeaturizer <double_t> */
+/* |  LabelEncoderFeaturizer <double> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void LabelEncoderFeaturizer_double_t_Test(
+void LabelEncoderFeaturizer_double_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint32_t> const &)> const &verify_func,
+    std::function<bool (std::vector<std::uint32_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    LabelEncoderFeaturizer_double_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    LabelEncoderFeaturizer_double_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_double_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_double_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -977,7 +977,7 @@ void LabelEncoderFeaturizer_double_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(LabelEncoderFeaturizer_double_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_double_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -986,7 +986,7 @@ void LabelEncoderFeaturizer_double_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(LabelEncoderFeaturizer_double_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(LabelEncoderFeaturizer_double_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -996,7 +996,7 @@ void LabelEncoderFeaturizer_double_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(LabelEncoderFeaturizer_double_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(LabelEncoderFeaturizer_double_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -1004,7 +1004,7 @@ void LabelEncoderFeaturizer_double_t_Test(
         }
     }
 
-    LabelEncoderFeaturizer_double_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    LabelEncoderFeaturizer_double_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -1012,31 +1012,31 @@ void LabelEncoderFeaturizer_double_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(LabelEncoderFeaturizer_double_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_double_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    LabelEncoderFeaturizer_double_t_TransformerHandle * pTransformerHandle(nullptr);
+    LabelEncoderFeaturizer_double_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(LabelEncoderFeaturizer_double_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_double_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(LabelEncoderFeaturizer_double_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_double_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint32_t> results;
+    std::vector<std::uint32_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint32_t result;
+        std::uint32_t result;
 
-        REQUIRE(LabelEncoderFeaturizer_double_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(LabelEncoderFeaturizer_double_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -1053,7 +1053,7 @@ void LabelEncoderFeaturizer_double_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(LabelEncoderFeaturizer_double_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(LabelEncoderFeaturizer_double_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
@@ -1063,7 +1063,7 @@ template <typename VectorInputT, typename... ConstructorArgTs>
 void LabelEncoderFeaturizer_bool_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint32_t> const &)> const &verify_func,
+    std::function<bool (std::vector<std::uint32_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
@@ -1134,12 +1134,12 @@ void LabelEncoderFeaturizer_bool_Test(
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint32_t> results;
+    std::vector<std::uint32_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint32_t result;
+        std::uint32_t result;
 
         REQUIRE(LabelEncoderFeaturizer_bool_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
@@ -1168,7 +1168,7 @@ template <typename VectorInputT, typename... ConstructorArgTs>
 void LabelEncoderFeaturizer_string_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<uint32_t> const &)> const &verify_func,
+    std::function<bool (std::vector<std::uint32_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
@@ -1239,12 +1239,12 @@ void LabelEncoderFeaturizer_string_Test(
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<uint32_t> results;
+    std::vector<std::uint32_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        uint32_t result;
+        std::uint32_t result;
 
         REQUIRE(LabelEncoderFeaturizer_string_Transform(pTransformerHandle, input.c_str(), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);

--- a/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_MaxAbsScalarFeaturizer.h
+++ b/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_MaxAbsScalarFeaturizer.h
@@ -8,19 +8,19 @@
 #include "Traits.h"
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <int8_t> */
+/* |  MaxAbsScalarFeaturizer <int8> */
 template <typename VectorInputT>
-void MaxAbsScalarFeaturizer_int8_t_Test(
+void MaxAbsScalarFeaturizer_int8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<float> const &)> const &verify_func
+    std::function<bool (std::vector<std::float_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MaxAbsScalarFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MaxAbsScalarFeaturizer_int8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_int8_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int8_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -31,7 +31,7 @@ void MaxAbsScalarFeaturizer_int8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MaxAbsScalarFeaturizer_int8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_int8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -40,7 +40,7 @@ void MaxAbsScalarFeaturizer_int8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MaxAbsScalarFeaturizer_int8_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_int8_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -50,7 +50,7 @@ void MaxAbsScalarFeaturizer_int8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MaxAbsScalarFeaturizer_int8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MaxAbsScalarFeaturizer_int8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -58,7 +58,7 @@ void MaxAbsScalarFeaturizer_int8_t_Test(
         }
     }
 
-    MaxAbsScalarFeaturizer_int8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MaxAbsScalarFeaturizer_int8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -66,31 +66,31 @@ void MaxAbsScalarFeaturizer_int8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MaxAbsScalarFeaturizer_int8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_int8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MaxAbsScalarFeaturizer_int8_t_TransformerHandle * pTransformerHandle(nullptr);
+    MaxAbsScalarFeaturizer_int8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_int8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MaxAbsScalarFeaturizer_int8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<float> results;
+    std::vector<std::float_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        float result;
+        std::float_t result;
 
-        REQUIRE(MaxAbsScalarFeaturizer_int8_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_int8_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -107,24 +107,24 @@ void MaxAbsScalarFeaturizer_int8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MaxAbsScalarFeaturizer_int8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <int16_t> */
+/* |  MaxAbsScalarFeaturizer <int16> */
 template <typename VectorInputT>
-void MaxAbsScalarFeaturizer_int16_t_Test(
+void MaxAbsScalarFeaturizer_int16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<float> const &)> const &verify_func
+    std::function<bool (std::vector<std::float_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MaxAbsScalarFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MaxAbsScalarFeaturizer_int16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_int16_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int16_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -135,7 +135,7 @@ void MaxAbsScalarFeaturizer_int16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MaxAbsScalarFeaturizer_int16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_int16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -144,7 +144,7 @@ void MaxAbsScalarFeaturizer_int16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MaxAbsScalarFeaturizer_int16_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_int16_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -154,7 +154,7 @@ void MaxAbsScalarFeaturizer_int16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MaxAbsScalarFeaturizer_int16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MaxAbsScalarFeaturizer_int16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -162,7 +162,7 @@ void MaxAbsScalarFeaturizer_int16_t_Test(
         }
     }
 
-    MaxAbsScalarFeaturizer_int16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MaxAbsScalarFeaturizer_int16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -170,31 +170,31 @@ void MaxAbsScalarFeaturizer_int16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MaxAbsScalarFeaturizer_int16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_int16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MaxAbsScalarFeaturizer_int16_t_TransformerHandle * pTransformerHandle(nullptr);
+    MaxAbsScalarFeaturizer_int16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_int16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MaxAbsScalarFeaturizer_int16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<float> results;
+    std::vector<std::float_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        float result;
+        std::float_t result;
 
-        REQUIRE(MaxAbsScalarFeaturizer_int16_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_int16_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -211,24 +211,24 @@ void MaxAbsScalarFeaturizer_int16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MaxAbsScalarFeaturizer_int16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <uint8_t> */
+/* |  MaxAbsScalarFeaturizer <uint8> */
 template <typename VectorInputT>
-void MaxAbsScalarFeaturizer_uint8_t_Test(
+void MaxAbsScalarFeaturizer_uint8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<float> const &)> const &verify_func
+    std::function<bool (std::vector<std::float_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MaxAbsScalarFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MaxAbsScalarFeaturizer_uint8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_uint8_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint8_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -239,7 +239,7 @@ void MaxAbsScalarFeaturizer_uint8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MaxAbsScalarFeaturizer_uint8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_uint8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -248,7 +248,7 @@ void MaxAbsScalarFeaturizer_uint8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MaxAbsScalarFeaturizer_uint8_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_uint8_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -258,7 +258,7 @@ void MaxAbsScalarFeaturizer_uint8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MaxAbsScalarFeaturizer_uint8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MaxAbsScalarFeaturizer_uint8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -266,7 +266,7 @@ void MaxAbsScalarFeaturizer_uint8_t_Test(
         }
     }
 
-    MaxAbsScalarFeaturizer_uint8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MaxAbsScalarFeaturizer_uint8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -274,31 +274,31 @@ void MaxAbsScalarFeaturizer_uint8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MaxAbsScalarFeaturizer_uint8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_uint8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MaxAbsScalarFeaturizer_uint8_t_TransformerHandle * pTransformerHandle(nullptr);
+    MaxAbsScalarFeaturizer_uint8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_uint8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MaxAbsScalarFeaturizer_uint8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<float> results;
+    std::vector<std::float_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        float result;
+        std::float_t result;
 
-        REQUIRE(MaxAbsScalarFeaturizer_uint8_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_uint8_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -315,24 +315,24 @@ void MaxAbsScalarFeaturizer_uint8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MaxAbsScalarFeaturizer_uint8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <uint16_t> */
+/* |  MaxAbsScalarFeaturizer <uint16> */
 template <typename VectorInputT>
-void MaxAbsScalarFeaturizer_uint16_t_Test(
+void MaxAbsScalarFeaturizer_uint16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<float> const &)> const &verify_func
+    std::function<bool (std::vector<std::float_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MaxAbsScalarFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MaxAbsScalarFeaturizer_uint16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_uint16_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint16_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -343,7 +343,7 @@ void MaxAbsScalarFeaturizer_uint16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MaxAbsScalarFeaturizer_uint16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_uint16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -352,7 +352,7 @@ void MaxAbsScalarFeaturizer_uint16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MaxAbsScalarFeaturizer_uint16_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_uint16_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -362,7 +362,7 @@ void MaxAbsScalarFeaturizer_uint16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MaxAbsScalarFeaturizer_uint16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MaxAbsScalarFeaturizer_uint16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -370,7 +370,7 @@ void MaxAbsScalarFeaturizer_uint16_t_Test(
         }
     }
 
-    MaxAbsScalarFeaturizer_uint16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MaxAbsScalarFeaturizer_uint16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -378,31 +378,31 @@ void MaxAbsScalarFeaturizer_uint16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MaxAbsScalarFeaturizer_uint16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_uint16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MaxAbsScalarFeaturizer_uint16_t_TransformerHandle * pTransformerHandle(nullptr);
+    MaxAbsScalarFeaturizer_uint16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_uint16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MaxAbsScalarFeaturizer_uint16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<float> results;
+    std::vector<std::float_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        float result;
+        std::float_t result;
 
-        REQUIRE(MaxAbsScalarFeaturizer_uint16_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_uint16_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -419,24 +419,24 @@ void MaxAbsScalarFeaturizer_uint16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MaxAbsScalarFeaturizer_uint16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <float_t> */
+/* |  MaxAbsScalarFeaturizer <float> */
 template <typename VectorInputT>
-void MaxAbsScalarFeaturizer_float_t_Test(
+void MaxAbsScalarFeaturizer_float_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<float> const &)> const &verify_func
+    std::function<bool (std::vector<std::float_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MaxAbsScalarFeaturizer_float_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MaxAbsScalarFeaturizer_float_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_float_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_float_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -447,7 +447,7 @@ void MaxAbsScalarFeaturizer_float_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MaxAbsScalarFeaturizer_float_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_float_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -456,7 +456,7 @@ void MaxAbsScalarFeaturizer_float_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MaxAbsScalarFeaturizer_float_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_float_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -466,7 +466,7 @@ void MaxAbsScalarFeaturizer_float_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MaxAbsScalarFeaturizer_float_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MaxAbsScalarFeaturizer_float_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -474,7 +474,7 @@ void MaxAbsScalarFeaturizer_float_t_Test(
         }
     }
 
-    MaxAbsScalarFeaturizer_float_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MaxAbsScalarFeaturizer_float_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -482,31 +482,31 @@ void MaxAbsScalarFeaturizer_float_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MaxAbsScalarFeaturizer_float_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_float_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MaxAbsScalarFeaturizer_float_t_TransformerHandle * pTransformerHandle(nullptr);
+    MaxAbsScalarFeaturizer_float_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_float_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_float_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MaxAbsScalarFeaturizer_float_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_float_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<float> results;
+    std::vector<std::float_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        float result;
+        std::float_t result;
 
-        REQUIRE(MaxAbsScalarFeaturizer_float_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_float_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -523,24 +523,24 @@ void MaxAbsScalarFeaturizer_float_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MaxAbsScalarFeaturizer_float_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_float_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <int32_t> */
+/* |  MaxAbsScalarFeaturizer <int32> */
 template <typename VectorInputT>
-void MaxAbsScalarFeaturizer_int32_t_Test(
+void MaxAbsScalarFeaturizer_int32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MaxAbsScalarFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MaxAbsScalarFeaturizer_int32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_int32_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int32_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -551,7 +551,7 @@ void MaxAbsScalarFeaturizer_int32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MaxAbsScalarFeaturizer_int32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_int32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -560,7 +560,7 @@ void MaxAbsScalarFeaturizer_int32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MaxAbsScalarFeaturizer_int32_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_int32_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -570,7 +570,7 @@ void MaxAbsScalarFeaturizer_int32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MaxAbsScalarFeaturizer_int32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MaxAbsScalarFeaturizer_int32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -578,7 +578,7 @@ void MaxAbsScalarFeaturizer_int32_t_Test(
         }
     }
 
-    MaxAbsScalarFeaturizer_int32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MaxAbsScalarFeaturizer_int32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -586,31 +586,31 @@ void MaxAbsScalarFeaturizer_int32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MaxAbsScalarFeaturizer_int32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_int32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MaxAbsScalarFeaturizer_int32_t_TransformerHandle * pTransformerHandle(nullptr);
+    MaxAbsScalarFeaturizer_int32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_int32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MaxAbsScalarFeaturizer_int32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MaxAbsScalarFeaturizer_int32_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_int32_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -627,24 +627,24 @@ void MaxAbsScalarFeaturizer_int32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MaxAbsScalarFeaturizer_int32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <int64_t> */
+/* |  MaxAbsScalarFeaturizer <int64> */
 template <typename VectorInputT>
-void MaxAbsScalarFeaturizer_int64_t_Test(
+void MaxAbsScalarFeaturizer_int64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MaxAbsScalarFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MaxAbsScalarFeaturizer_int64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_int64_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int64_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -655,7 +655,7 @@ void MaxAbsScalarFeaturizer_int64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MaxAbsScalarFeaturizer_int64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_int64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -664,7 +664,7 @@ void MaxAbsScalarFeaturizer_int64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MaxAbsScalarFeaturizer_int64_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_int64_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -674,7 +674,7 @@ void MaxAbsScalarFeaturizer_int64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MaxAbsScalarFeaturizer_int64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MaxAbsScalarFeaturizer_int64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -682,7 +682,7 @@ void MaxAbsScalarFeaturizer_int64_t_Test(
         }
     }
 
-    MaxAbsScalarFeaturizer_int64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MaxAbsScalarFeaturizer_int64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -690,31 +690,31 @@ void MaxAbsScalarFeaturizer_int64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MaxAbsScalarFeaturizer_int64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_int64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MaxAbsScalarFeaturizer_int64_t_TransformerHandle * pTransformerHandle(nullptr);
+    MaxAbsScalarFeaturizer_int64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_int64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MaxAbsScalarFeaturizer_int64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MaxAbsScalarFeaturizer_int64_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_int64_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -731,24 +731,24 @@ void MaxAbsScalarFeaturizer_int64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MaxAbsScalarFeaturizer_int64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_int64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <uint32_t> */
+/* |  MaxAbsScalarFeaturizer <uint32> */
 template <typename VectorInputT>
-void MaxAbsScalarFeaturizer_uint32_t_Test(
+void MaxAbsScalarFeaturizer_uint32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MaxAbsScalarFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MaxAbsScalarFeaturizer_uint32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_uint32_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint32_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -759,7 +759,7 @@ void MaxAbsScalarFeaturizer_uint32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MaxAbsScalarFeaturizer_uint32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_uint32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -768,7 +768,7 @@ void MaxAbsScalarFeaturizer_uint32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MaxAbsScalarFeaturizer_uint32_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_uint32_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -778,7 +778,7 @@ void MaxAbsScalarFeaturizer_uint32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MaxAbsScalarFeaturizer_uint32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MaxAbsScalarFeaturizer_uint32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -786,7 +786,7 @@ void MaxAbsScalarFeaturizer_uint32_t_Test(
         }
     }
 
-    MaxAbsScalarFeaturizer_uint32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MaxAbsScalarFeaturizer_uint32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -794,31 +794,31 @@ void MaxAbsScalarFeaturizer_uint32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MaxAbsScalarFeaturizer_uint32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_uint32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MaxAbsScalarFeaturizer_uint32_t_TransformerHandle * pTransformerHandle(nullptr);
+    MaxAbsScalarFeaturizer_uint32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_uint32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MaxAbsScalarFeaturizer_uint32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MaxAbsScalarFeaturizer_uint32_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_uint32_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -835,24 +835,24 @@ void MaxAbsScalarFeaturizer_uint32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MaxAbsScalarFeaturizer_uint32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <uint64_t> */
+/* |  MaxAbsScalarFeaturizer <uint64> */
 template <typename VectorInputT>
-void MaxAbsScalarFeaturizer_uint64_t_Test(
+void MaxAbsScalarFeaturizer_uint64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MaxAbsScalarFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MaxAbsScalarFeaturizer_uint64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_uint64_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint64_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -863,7 +863,7 @@ void MaxAbsScalarFeaturizer_uint64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MaxAbsScalarFeaturizer_uint64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_uint64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -872,7 +872,7 @@ void MaxAbsScalarFeaturizer_uint64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MaxAbsScalarFeaturizer_uint64_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_uint64_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -882,7 +882,7 @@ void MaxAbsScalarFeaturizer_uint64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MaxAbsScalarFeaturizer_uint64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MaxAbsScalarFeaturizer_uint64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -890,7 +890,7 @@ void MaxAbsScalarFeaturizer_uint64_t_Test(
         }
     }
 
-    MaxAbsScalarFeaturizer_uint64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MaxAbsScalarFeaturizer_uint64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -898,31 +898,31 @@ void MaxAbsScalarFeaturizer_uint64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MaxAbsScalarFeaturizer_uint64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_uint64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MaxAbsScalarFeaturizer_uint64_t_TransformerHandle * pTransformerHandle(nullptr);
+    MaxAbsScalarFeaturizer_uint64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_uint64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MaxAbsScalarFeaturizer_uint64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MaxAbsScalarFeaturizer_uint64_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_uint64_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -939,24 +939,24 @@ void MaxAbsScalarFeaturizer_uint64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MaxAbsScalarFeaturizer_uint64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_uint64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MaxAbsScalarFeaturizer <double_t> */
+/* |  MaxAbsScalarFeaturizer <double> */
 template <typename VectorInputT>
-void MaxAbsScalarFeaturizer_double_t_Test(
+void MaxAbsScalarFeaturizer_double_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MaxAbsScalarFeaturizer_double_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MaxAbsScalarFeaturizer_double_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_double_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_double_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -967,7 +967,7 @@ void MaxAbsScalarFeaturizer_double_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MaxAbsScalarFeaturizer_double_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_double_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -976,7 +976,7 @@ void MaxAbsScalarFeaturizer_double_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MaxAbsScalarFeaturizer_double_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MaxAbsScalarFeaturizer_double_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -986,7 +986,7 @@ void MaxAbsScalarFeaturizer_double_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MaxAbsScalarFeaturizer_double_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MaxAbsScalarFeaturizer_double_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -994,7 +994,7 @@ void MaxAbsScalarFeaturizer_double_t_Test(
         }
     }
 
-    MaxAbsScalarFeaturizer_double_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MaxAbsScalarFeaturizer_double_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -1002,31 +1002,31 @@ void MaxAbsScalarFeaturizer_double_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MaxAbsScalarFeaturizer_double_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_double_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MaxAbsScalarFeaturizer_double_t_TransformerHandle * pTransformerHandle(nullptr);
+    MaxAbsScalarFeaturizer_double_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MaxAbsScalarFeaturizer_double_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_double_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MaxAbsScalarFeaturizer_double_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_double_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MaxAbsScalarFeaturizer_double_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MaxAbsScalarFeaturizer_double_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -1043,7 +1043,7 @@ void MaxAbsScalarFeaturizer_double_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MaxAbsScalarFeaturizer_double_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MaxAbsScalarFeaturizer_double_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 

--- a/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_MinMaxScalarFeaturizer.h
+++ b/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_MinMaxScalarFeaturizer.h
@@ -8,19 +8,19 @@
 #include "Traits.h"
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <int8_t> */
+/* |  MinMaxScalarFeaturizer <int8> */
 template <typename VectorInputT>
-void MinMaxScalarFeaturizer_int8_t_Test(
+void MinMaxScalarFeaturizer_int8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MinMaxScalarFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MinMaxScalarFeaturizer_int8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_int8_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int8_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -31,7 +31,7 @@ void MinMaxScalarFeaturizer_int8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MinMaxScalarFeaturizer_int8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_int8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -40,7 +40,7 @@ void MinMaxScalarFeaturizer_int8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MinMaxScalarFeaturizer_int8_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_int8_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -50,7 +50,7 @@ void MinMaxScalarFeaturizer_int8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MinMaxScalarFeaturizer_int8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MinMaxScalarFeaturizer_int8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -58,7 +58,7 @@ void MinMaxScalarFeaturizer_int8_t_Test(
         }
     }
 
-    MinMaxScalarFeaturizer_int8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MinMaxScalarFeaturizer_int8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -66,31 +66,31 @@ void MinMaxScalarFeaturizer_int8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MinMaxScalarFeaturizer_int8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_int8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MinMaxScalarFeaturizer_int8_t_TransformerHandle * pTransformerHandle(nullptr);
+    MinMaxScalarFeaturizer_int8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_int8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MinMaxScalarFeaturizer_int8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MinMaxScalarFeaturizer_int8_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_int8_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -107,24 +107,24 @@ void MinMaxScalarFeaturizer_int8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MinMaxScalarFeaturizer_int8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <int16_t> */
+/* |  MinMaxScalarFeaturizer <int16> */
 template <typename VectorInputT>
-void MinMaxScalarFeaturizer_int16_t_Test(
+void MinMaxScalarFeaturizer_int16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MinMaxScalarFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MinMaxScalarFeaturizer_int16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_int16_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int16_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -135,7 +135,7 @@ void MinMaxScalarFeaturizer_int16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MinMaxScalarFeaturizer_int16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_int16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -144,7 +144,7 @@ void MinMaxScalarFeaturizer_int16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MinMaxScalarFeaturizer_int16_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_int16_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -154,7 +154,7 @@ void MinMaxScalarFeaturizer_int16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MinMaxScalarFeaturizer_int16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MinMaxScalarFeaturizer_int16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -162,7 +162,7 @@ void MinMaxScalarFeaturizer_int16_t_Test(
         }
     }
 
-    MinMaxScalarFeaturizer_int16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MinMaxScalarFeaturizer_int16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -170,31 +170,31 @@ void MinMaxScalarFeaturizer_int16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MinMaxScalarFeaturizer_int16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_int16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MinMaxScalarFeaturizer_int16_t_TransformerHandle * pTransformerHandle(nullptr);
+    MinMaxScalarFeaturizer_int16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_int16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MinMaxScalarFeaturizer_int16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MinMaxScalarFeaturizer_int16_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_int16_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -211,24 +211,24 @@ void MinMaxScalarFeaturizer_int16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MinMaxScalarFeaturizer_int16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <int32_t> */
+/* |  MinMaxScalarFeaturizer <int32> */
 template <typename VectorInputT>
-void MinMaxScalarFeaturizer_int32_t_Test(
+void MinMaxScalarFeaturizer_int32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MinMaxScalarFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MinMaxScalarFeaturizer_int32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_int32_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int32_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -239,7 +239,7 @@ void MinMaxScalarFeaturizer_int32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MinMaxScalarFeaturizer_int32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_int32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -248,7 +248,7 @@ void MinMaxScalarFeaturizer_int32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MinMaxScalarFeaturizer_int32_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_int32_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -258,7 +258,7 @@ void MinMaxScalarFeaturizer_int32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MinMaxScalarFeaturizer_int32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MinMaxScalarFeaturizer_int32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -266,7 +266,7 @@ void MinMaxScalarFeaturizer_int32_t_Test(
         }
     }
 
-    MinMaxScalarFeaturizer_int32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MinMaxScalarFeaturizer_int32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -274,31 +274,31 @@ void MinMaxScalarFeaturizer_int32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MinMaxScalarFeaturizer_int32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_int32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MinMaxScalarFeaturizer_int32_t_TransformerHandle * pTransformerHandle(nullptr);
+    MinMaxScalarFeaturizer_int32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_int32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MinMaxScalarFeaturizer_int32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MinMaxScalarFeaturizer_int32_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_int32_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -315,24 +315,24 @@ void MinMaxScalarFeaturizer_int32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MinMaxScalarFeaturizer_int32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <int64_t> */
+/* |  MinMaxScalarFeaturizer <int64> */
 template <typename VectorInputT>
-void MinMaxScalarFeaturizer_int64_t_Test(
+void MinMaxScalarFeaturizer_int64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MinMaxScalarFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MinMaxScalarFeaturizer_int64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_int64_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int64_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -343,7 +343,7 @@ void MinMaxScalarFeaturizer_int64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MinMaxScalarFeaturizer_int64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_int64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -352,7 +352,7 @@ void MinMaxScalarFeaturizer_int64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MinMaxScalarFeaturizer_int64_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_int64_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -362,7 +362,7 @@ void MinMaxScalarFeaturizer_int64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MinMaxScalarFeaturizer_int64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MinMaxScalarFeaturizer_int64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -370,7 +370,7 @@ void MinMaxScalarFeaturizer_int64_t_Test(
         }
     }
 
-    MinMaxScalarFeaturizer_int64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MinMaxScalarFeaturizer_int64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -378,31 +378,31 @@ void MinMaxScalarFeaturizer_int64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MinMaxScalarFeaturizer_int64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_int64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MinMaxScalarFeaturizer_int64_t_TransformerHandle * pTransformerHandle(nullptr);
+    MinMaxScalarFeaturizer_int64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_int64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MinMaxScalarFeaturizer_int64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MinMaxScalarFeaturizer_int64_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_int64_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -419,24 +419,24 @@ void MinMaxScalarFeaturizer_int64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MinMaxScalarFeaturizer_int64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_int64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <uint8_t> */
+/* |  MinMaxScalarFeaturizer <uint8> */
 template <typename VectorInputT>
-void MinMaxScalarFeaturizer_uint8_t_Test(
+void MinMaxScalarFeaturizer_uint8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MinMaxScalarFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MinMaxScalarFeaturizer_uint8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_uint8_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint8_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -447,7 +447,7 @@ void MinMaxScalarFeaturizer_uint8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MinMaxScalarFeaturizer_uint8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_uint8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -456,7 +456,7 @@ void MinMaxScalarFeaturizer_uint8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MinMaxScalarFeaturizer_uint8_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_uint8_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -466,7 +466,7 @@ void MinMaxScalarFeaturizer_uint8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MinMaxScalarFeaturizer_uint8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MinMaxScalarFeaturizer_uint8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -474,7 +474,7 @@ void MinMaxScalarFeaturizer_uint8_t_Test(
         }
     }
 
-    MinMaxScalarFeaturizer_uint8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MinMaxScalarFeaturizer_uint8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -482,31 +482,31 @@ void MinMaxScalarFeaturizer_uint8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MinMaxScalarFeaturizer_uint8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_uint8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MinMaxScalarFeaturizer_uint8_t_TransformerHandle * pTransformerHandle(nullptr);
+    MinMaxScalarFeaturizer_uint8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_uint8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MinMaxScalarFeaturizer_uint8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MinMaxScalarFeaturizer_uint8_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_uint8_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -523,24 +523,24 @@ void MinMaxScalarFeaturizer_uint8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MinMaxScalarFeaturizer_uint8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <uint16_t> */
+/* |  MinMaxScalarFeaturizer <uint16> */
 template <typename VectorInputT>
-void MinMaxScalarFeaturizer_uint16_t_Test(
+void MinMaxScalarFeaturizer_uint16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MinMaxScalarFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MinMaxScalarFeaturizer_uint16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_uint16_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint16_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -551,7 +551,7 @@ void MinMaxScalarFeaturizer_uint16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MinMaxScalarFeaturizer_uint16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_uint16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -560,7 +560,7 @@ void MinMaxScalarFeaturizer_uint16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MinMaxScalarFeaturizer_uint16_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_uint16_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -570,7 +570,7 @@ void MinMaxScalarFeaturizer_uint16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MinMaxScalarFeaturizer_uint16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MinMaxScalarFeaturizer_uint16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -578,7 +578,7 @@ void MinMaxScalarFeaturizer_uint16_t_Test(
         }
     }
 
-    MinMaxScalarFeaturizer_uint16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MinMaxScalarFeaturizer_uint16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -586,31 +586,31 @@ void MinMaxScalarFeaturizer_uint16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MinMaxScalarFeaturizer_uint16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_uint16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MinMaxScalarFeaturizer_uint16_t_TransformerHandle * pTransformerHandle(nullptr);
+    MinMaxScalarFeaturizer_uint16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_uint16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MinMaxScalarFeaturizer_uint16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MinMaxScalarFeaturizer_uint16_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_uint16_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -627,24 +627,24 @@ void MinMaxScalarFeaturizer_uint16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MinMaxScalarFeaturizer_uint16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <uint32_t> */
+/* |  MinMaxScalarFeaturizer <uint32> */
 template <typename VectorInputT>
-void MinMaxScalarFeaturizer_uint32_t_Test(
+void MinMaxScalarFeaturizer_uint32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MinMaxScalarFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MinMaxScalarFeaturizer_uint32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_uint32_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint32_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -655,7 +655,7 @@ void MinMaxScalarFeaturizer_uint32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MinMaxScalarFeaturizer_uint32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_uint32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -664,7 +664,7 @@ void MinMaxScalarFeaturizer_uint32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MinMaxScalarFeaturizer_uint32_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_uint32_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -674,7 +674,7 @@ void MinMaxScalarFeaturizer_uint32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MinMaxScalarFeaturizer_uint32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MinMaxScalarFeaturizer_uint32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -682,7 +682,7 @@ void MinMaxScalarFeaturizer_uint32_t_Test(
         }
     }
 
-    MinMaxScalarFeaturizer_uint32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MinMaxScalarFeaturizer_uint32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -690,31 +690,31 @@ void MinMaxScalarFeaturizer_uint32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MinMaxScalarFeaturizer_uint32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_uint32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MinMaxScalarFeaturizer_uint32_t_TransformerHandle * pTransformerHandle(nullptr);
+    MinMaxScalarFeaturizer_uint32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_uint32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MinMaxScalarFeaturizer_uint32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MinMaxScalarFeaturizer_uint32_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_uint32_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -731,24 +731,24 @@ void MinMaxScalarFeaturizer_uint32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MinMaxScalarFeaturizer_uint32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <uint64_t> */
+/* |  MinMaxScalarFeaturizer <uint64> */
 template <typename VectorInputT>
-void MinMaxScalarFeaturizer_uint64_t_Test(
+void MinMaxScalarFeaturizer_uint64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MinMaxScalarFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MinMaxScalarFeaturizer_uint64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_uint64_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint64_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -759,7 +759,7 @@ void MinMaxScalarFeaturizer_uint64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MinMaxScalarFeaturizer_uint64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_uint64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -768,7 +768,7 @@ void MinMaxScalarFeaturizer_uint64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MinMaxScalarFeaturizer_uint64_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_uint64_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -778,7 +778,7 @@ void MinMaxScalarFeaturizer_uint64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MinMaxScalarFeaturizer_uint64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MinMaxScalarFeaturizer_uint64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -786,7 +786,7 @@ void MinMaxScalarFeaturizer_uint64_t_Test(
         }
     }
 
-    MinMaxScalarFeaturizer_uint64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MinMaxScalarFeaturizer_uint64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -794,31 +794,31 @@ void MinMaxScalarFeaturizer_uint64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MinMaxScalarFeaturizer_uint64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_uint64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MinMaxScalarFeaturizer_uint64_t_TransformerHandle * pTransformerHandle(nullptr);
+    MinMaxScalarFeaturizer_uint64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_uint64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MinMaxScalarFeaturizer_uint64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MinMaxScalarFeaturizer_uint64_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_uint64_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -835,24 +835,24 @@ void MinMaxScalarFeaturizer_uint64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MinMaxScalarFeaturizer_uint64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_uint64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <float_t> */
+/* |  MinMaxScalarFeaturizer <float> */
 template <typename VectorInputT>
-void MinMaxScalarFeaturizer_float_t_Test(
+void MinMaxScalarFeaturizer_float_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MinMaxScalarFeaturizer_float_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MinMaxScalarFeaturizer_float_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_float_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_float_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -863,7 +863,7 @@ void MinMaxScalarFeaturizer_float_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MinMaxScalarFeaturizer_float_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_float_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -872,7 +872,7 @@ void MinMaxScalarFeaturizer_float_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MinMaxScalarFeaturizer_float_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_float_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -882,7 +882,7 @@ void MinMaxScalarFeaturizer_float_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MinMaxScalarFeaturizer_float_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MinMaxScalarFeaturizer_float_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -890,7 +890,7 @@ void MinMaxScalarFeaturizer_float_t_Test(
         }
     }
 
-    MinMaxScalarFeaturizer_float_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MinMaxScalarFeaturizer_float_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -898,31 +898,31 @@ void MinMaxScalarFeaturizer_float_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MinMaxScalarFeaturizer_float_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_float_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MinMaxScalarFeaturizer_float_t_TransformerHandle * pTransformerHandle(nullptr);
+    MinMaxScalarFeaturizer_float_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_float_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_float_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MinMaxScalarFeaturizer_float_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_float_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MinMaxScalarFeaturizer_float_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_float_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -939,24 +939,24 @@ void MinMaxScalarFeaturizer_float_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MinMaxScalarFeaturizer_float_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_float_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MinMaxScalarFeaturizer <double_t> */
+/* |  MinMaxScalarFeaturizer <double> */
 template <typename VectorInputT>
-void MinMaxScalarFeaturizer_double_t_Test(
+void MinMaxScalarFeaturizer_double_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MinMaxScalarFeaturizer_double_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MinMaxScalarFeaturizer_double_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_double_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_double_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -967,7 +967,7 @@ void MinMaxScalarFeaturizer_double_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MinMaxScalarFeaturizer_double_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_double_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -976,7 +976,7 @@ void MinMaxScalarFeaturizer_double_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MinMaxScalarFeaturizer_double_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(MinMaxScalarFeaturizer_double_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -986,7 +986,7 @@ void MinMaxScalarFeaturizer_double_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MinMaxScalarFeaturizer_double_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MinMaxScalarFeaturizer_double_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -994,7 +994,7 @@ void MinMaxScalarFeaturizer_double_t_Test(
         }
     }
 
-    MinMaxScalarFeaturizer_double_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MinMaxScalarFeaturizer_double_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -1002,31 +1002,31 @@ void MinMaxScalarFeaturizer_double_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MinMaxScalarFeaturizer_double_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_double_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MinMaxScalarFeaturizer_double_t_TransformerHandle * pTransformerHandle(nullptr);
+    MinMaxScalarFeaturizer_double_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MinMaxScalarFeaturizer_double_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_double_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MinMaxScalarFeaturizer_double_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_double_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(MinMaxScalarFeaturizer_double_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(MinMaxScalarFeaturizer_double_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -1043,7 +1043,7 @@ void MinMaxScalarFeaturizer_double_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MinMaxScalarFeaturizer_double_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MinMaxScalarFeaturizer_double_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 

--- a/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_MissingDummiesFeaturizer.h
+++ b/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_MissingDummiesFeaturizer.h
@@ -8,19 +8,19 @@
 #include "Traits.h"
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <int8_t> */
+/* |  MissingDummiesFeaturizer <int8> */
 template <typename VectorInputT>
-void MissingDummiesFeaturizer_int8_t_Test(
+void MissingDummiesFeaturizer_int8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int8_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int8_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MissingDummiesFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MissingDummiesFeaturizer_int8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_int8_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int8_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -31,7 +31,7 @@ void MissingDummiesFeaturizer_int8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MissingDummiesFeaturizer_int8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_int8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -40,7 +40,7 @@ void MissingDummiesFeaturizer_int8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MissingDummiesFeaturizer_int8_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<int8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int8_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_int8_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::int8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int8_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -50,7 +50,7 @@ void MissingDummiesFeaturizer_int8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MissingDummiesFeaturizer_int8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MissingDummiesFeaturizer_int8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -58,7 +58,7 @@ void MissingDummiesFeaturizer_int8_t_Test(
         }
     }
 
-    MissingDummiesFeaturizer_int8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MissingDummiesFeaturizer_int8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -66,31 +66,31 @@ void MissingDummiesFeaturizer_int8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MissingDummiesFeaturizer_int8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_int8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MissingDummiesFeaturizer_int8_t_TransformerHandle * pTransformerHandle(nullptr);
+    MissingDummiesFeaturizer_int8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_int8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MissingDummiesFeaturizer_int8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int8_t> results;
+    std::vector<std::int8_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int8_t result;
+        std::int8_t result;
 
-        REQUIRE(MissingDummiesFeaturizer_int8_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<int8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int8_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_int8_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::int8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int8_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -107,24 +107,24 @@ void MissingDummiesFeaturizer_int8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MissingDummiesFeaturizer_int8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <int16_t> */
+/* |  MissingDummiesFeaturizer <int16> */
 template <typename VectorInputT>
-void MissingDummiesFeaturizer_int16_t_Test(
+void MissingDummiesFeaturizer_int16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int8_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int8_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MissingDummiesFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MissingDummiesFeaturizer_int16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_int16_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int16_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -135,7 +135,7 @@ void MissingDummiesFeaturizer_int16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MissingDummiesFeaturizer_int16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_int16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -144,7 +144,7 @@ void MissingDummiesFeaturizer_int16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MissingDummiesFeaturizer_int16_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<int16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int16_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_int16_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::int16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int16_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -154,7 +154,7 @@ void MissingDummiesFeaturizer_int16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MissingDummiesFeaturizer_int16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MissingDummiesFeaturizer_int16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -162,7 +162,7 @@ void MissingDummiesFeaturizer_int16_t_Test(
         }
     }
 
-    MissingDummiesFeaturizer_int16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MissingDummiesFeaturizer_int16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -170,31 +170,31 @@ void MissingDummiesFeaturizer_int16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MissingDummiesFeaturizer_int16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_int16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MissingDummiesFeaturizer_int16_t_TransformerHandle * pTransformerHandle(nullptr);
+    MissingDummiesFeaturizer_int16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_int16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MissingDummiesFeaturizer_int16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int8_t> results;
+    std::vector<std::int8_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int8_t result;
+        std::int8_t result;
 
-        REQUIRE(MissingDummiesFeaturizer_int16_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<int16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int16_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_int16_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::int16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int16_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -211,24 +211,24 @@ void MissingDummiesFeaturizer_int16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MissingDummiesFeaturizer_int16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <int32_t> */
+/* |  MissingDummiesFeaturizer <int32> */
 template <typename VectorInputT>
-void MissingDummiesFeaturizer_int32_t_Test(
+void MissingDummiesFeaturizer_int32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int8_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int8_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MissingDummiesFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MissingDummiesFeaturizer_int32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_int32_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int32_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -239,7 +239,7 @@ void MissingDummiesFeaturizer_int32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MissingDummiesFeaturizer_int32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_int32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -248,7 +248,7 @@ void MissingDummiesFeaturizer_int32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MissingDummiesFeaturizer_int32_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<int32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int32_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_int32_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::int32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int32_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -258,7 +258,7 @@ void MissingDummiesFeaturizer_int32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MissingDummiesFeaturizer_int32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MissingDummiesFeaturizer_int32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -266,7 +266,7 @@ void MissingDummiesFeaturizer_int32_t_Test(
         }
     }
 
-    MissingDummiesFeaturizer_int32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MissingDummiesFeaturizer_int32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -274,31 +274,31 @@ void MissingDummiesFeaturizer_int32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MissingDummiesFeaturizer_int32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_int32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MissingDummiesFeaturizer_int32_t_TransformerHandle * pTransformerHandle(nullptr);
+    MissingDummiesFeaturizer_int32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_int32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MissingDummiesFeaturizer_int32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int8_t> results;
+    std::vector<std::int8_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int8_t result;
+        std::int8_t result;
 
-        REQUIRE(MissingDummiesFeaturizer_int32_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<int32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int32_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_int32_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::int32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int32_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -315,24 +315,24 @@ void MissingDummiesFeaturizer_int32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MissingDummiesFeaturizer_int32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <int64_t> */
+/* |  MissingDummiesFeaturizer <int64> */
 template <typename VectorInputT>
-void MissingDummiesFeaturizer_int64_t_Test(
+void MissingDummiesFeaturizer_int64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int8_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int8_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MissingDummiesFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MissingDummiesFeaturizer_int64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_int64_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int64_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -343,7 +343,7 @@ void MissingDummiesFeaturizer_int64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MissingDummiesFeaturizer_int64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_int64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -352,7 +352,7 @@ void MissingDummiesFeaturizer_int64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MissingDummiesFeaturizer_int64_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<int64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int64_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_int64_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::int64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int64_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -362,7 +362,7 @@ void MissingDummiesFeaturizer_int64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MissingDummiesFeaturizer_int64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MissingDummiesFeaturizer_int64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -370,7 +370,7 @@ void MissingDummiesFeaturizer_int64_t_Test(
         }
     }
 
-    MissingDummiesFeaturizer_int64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MissingDummiesFeaturizer_int64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -378,31 +378,31 @@ void MissingDummiesFeaturizer_int64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MissingDummiesFeaturizer_int64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_int64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MissingDummiesFeaturizer_int64_t_TransformerHandle * pTransformerHandle(nullptr);
+    MissingDummiesFeaturizer_int64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_int64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MissingDummiesFeaturizer_int64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int8_t> results;
+    std::vector<std::int8_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int8_t result;
+        std::int8_t result;
 
-        REQUIRE(MissingDummiesFeaturizer_int64_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<int64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<int64_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_int64_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::int64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::int64_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -419,24 +419,24 @@ void MissingDummiesFeaturizer_int64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MissingDummiesFeaturizer_int64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_int64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <uint8_t> */
+/* |  MissingDummiesFeaturizer <uint8> */
 template <typename VectorInputT>
-void MissingDummiesFeaturizer_uint8_t_Test(
+void MissingDummiesFeaturizer_uint8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int8_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int8_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MissingDummiesFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MissingDummiesFeaturizer_uint8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_uint8_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint8_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -447,7 +447,7 @@ void MissingDummiesFeaturizer_uint8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MissingDummiesFeaturizer_uint8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_uint8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -456,7 +456,7 @@ void MissingDummiesFeaturizer_uint8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MissingDummiesFeaturizer_uint8_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<uint8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint8_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_uint8_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::uint8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint8_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -466,7 +466,7 @@ void MissingDummiesFeaturizer_uint8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MissingDummiesFeaturizer_uint8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MissingDummiesFeaturizer_uint8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -474,7 +474,7 @@ void MissingDummiesFeaturizer_uint8_t_Test(
         }
     }
 
-    MissingDummiesFeaturizer_uint8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MissingDummiesFeaturizer_uint8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -482,31 +482,31 @@ void MissingDummiesFeaturizer_uint8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MissingDummiesFeaturizer_uint8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_uint8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MissingDummiesFeaturizer_uint8_t_TransformerHandle * pTransformerHandle(nullptr);
+    MissingDummiesFeaturizer_uint8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_uint8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MissingDummiesFeaturizer_uint8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int8_t> results;
+    std::vector<std::int8_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int8_t result;
+        std::int8_t result;
 
-        REQUIRE(MissingDummiesFeaturizer_uint8_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<uint8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint8_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_uint8_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::uint8_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint8_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -523,24 +523,24 @@ void MissingDummiesFeaturizer_uint8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MissingDummiesFeaturizer_uint8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <uint16_t> */
+/* |  MissingDummiesFeaturizer <uint16> */
 template <typename VectorInputT>
-void MissingDummiesFeaturizer_uint16_t_Test(
+void MissingDummiesFeaturizer_uint16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int8_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int8_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MissingDummiesFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MissingDummiesFeaturizer_uint16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_uint16_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint16_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -551,7 +551,7 @@ void MissingDummiesFeaturizer_uint16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MissingDummiesFeaturizer_uint16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_uint16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -560,7 +560,7 @@ void MissingDummiesFeaturizer_uint16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MissingDummiesFeaturizer_uint16_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<uint16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint16_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_uint16_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::uint16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint16_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -570,7 +570,7 @@ void MissingDummiesFeaturizer_uint16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MissingDummiesFeaturizer_uint16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MissingDummiesFeaturizer_uint16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -578,7 +578,7 @@ void MissingDummiesFeaturizer_uint16_t_Test(
         }
     }
 
-    MissingDummiesFeaturizer_uint16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MissingDummiesFeaturizer_uint16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -586,31 +586,31 @@ void MissingDummiesFeaturizer_uint16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MissingDummiesFeaturizer_uint16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_uint16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MissingDummiesFeaturizer_uint16_t_TransformerHandle * pTransformerHandle(nullptr);
+    MissingDummiesFeaturizer_uint16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_uint16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MissingDummiesFeaturizer_uint16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int8_t> results;
+    std::vector<std::int8_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int8_t result;
+        std::int8_t result;
 
-        REQUIRE(MissingDummiesFeaturizer_uint16_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<uint16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint16_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_uint16_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::uint16_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint16_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -627,24 +627,24 @@ void MissingDummiesFeaturizer_uint16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MissingDummiesFeaturizer_uint16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <uint32_t> */
+/* |  MissingDummiesFeaturizer <uint32> */
 template <typename VectorInputT>
-void MissingDummiesFeaturizer_uint32_t_Test(
+void MissingDummiesFeaturizer_uint32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int8_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int8_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MissingDummiesFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MissingDummiesFeaturizer_uint32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_uint32_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint32_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -655,7 +655,7 @@ void MissingDummiesFeaturizer_uint32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MissingDummiesFeaturizer_uint32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_uint32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -664,7 +664,7 @@ void MissingDummiesFeaturizer_uint32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MissingDummiesFeaturizer_uint32_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<uint32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint32_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_uint32_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::uint32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint32_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -674,7 +674,7 @@ void MissingDummiesFeaturizer_uint32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MissingDummiesFeaturizer_uint32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MissingDummiesFeaturizer_uint32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -682,7 +682,7 @@ void MissingDummiesFeaturizer_uint32_t_Test(
         }
     }
 
-    MissingDummiesFeaturizer_uint32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MissingDummiesFeaturizer_uint32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -690,31 +690,31 @@ void MissingDummiesFeaturizer_uint32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MissingDummiesFeaturizer_uint32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_uint32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MissingDummiesFeaturizer_uint32_t_TransformerHandle * pTransformerHandle(nullptr);
+    MissingDummiesFeaturizer_uint32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_uint32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MissingDummiesFeaturizer_uint32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int8_t> results;
+    std::vector<std::int8_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int8_t result;
+        std::int8_t result;
 
-        REQUIRE(MissingDummiesFeaturizer_uint32_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<uint32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint32_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_uint32_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::uint32_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint32_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -731,24 +731,24 @@ void MissingDummiesFeaturizer_uint32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MissingDummiesFeaturizer_uint32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <uint64_t> */
+/* |  MissingDummiesFeaturizer <uint64> */
 template <typename VectorInputT>
-void MissingDummiesFeaturizer_uint64_t_Test(
+void MissingDummiesFeaturizer_uint64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int8_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int8_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MissingDummiesFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MissingDummiesFeaturizer_uint64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_uint64_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint64_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -759,7 +759,7 @@ void MissingDummiesFeaturizer_uint64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MissingDummiesFeaturizer_uint64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_uint64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -768,7 +768,7 @@ void MissingDummiesFeaturizer_uint64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MissingDummiesFeaturizer_uint64_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<uint64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint64_t>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_uint64_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::uint64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint64_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -778,7 +778,7 @@ void MissingDummiesFeaturizer_uint64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MissingDummiesFeaturizer_uint64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MissingDummiesFeaturizer_uint64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -786,7 +786,7 @@ void MissingDummiesFeaturizer_uint64_t_Test(
         }
     }
 
-    MissingDummiesFeaturizer_uint64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MissingDummiesFeaturizer_uint64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -794,31 +794,31 @@ void MissingDummiesFeaturizer_uint64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MissingDummiesFeaturizer_uint64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_uint64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MissingDummiesFeaturizer_uint64_t_TransformerHandle * pTransformerHandle(nullptr);
+    MissingDummiesFeaturizer_uint64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_uint64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MissingDummiesFeaturizer_uint64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int8_t> results;
+    std::vector<std::int8_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int8_t result;
+        std::int8_t result;
 
-        REQUIRE(MissingDummiesFeaturizer_uint64_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<uint64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<uint64_t>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_uint64_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::uint64_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::uint64_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -835,24 +835,24 @@ void MissingDummiesFeaturizer_uint64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MissingDummiesFeaturizer_uint64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_uint64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <float_t> */
+/* |  MissingDummiesFeaturizer <float> */
 template <typename VectorInputT>
-void MissingDummiesFeaturizer_float_t_Test(
+void MissingDummiesFeaturizer_float_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int8_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int8_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MissingDummiesFeaturizer_float_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MissingDummiesFeaturizer_float_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_float_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_float_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -863,7 +863,7 @@ void MissingDummiesFeaturizer_float_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MissingDummiesFeaturizer_float_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_float_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -872,7 +872,7 @@ void MissingDummiesFeaturizer_float_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MissingDummiesFeaturizer_float_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<float>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<float>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_float_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::float_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::float_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -882,7 +882,7 @@ void MissingDummiesFeaturizer_float_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MissingDummiesFeaturizer_float_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MissingDummiesFeaturizer_float_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -890,7 +890,7 @@ void MissingDummiesFeaturizer_float_t_Test(
         }
     }
 
-    MissingDummiesFeaturizer_float_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MissingDummiesFeaturizer_float_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -898,31 +898,31 @@ void MissingDummiesFeaturizer_float_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MissingDummiesFeaturizer_float_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_float_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MissingDummiesFeaturizer_float_t_TransformerHandle * pTransformerHandle(nullptr);
+    MissingDummiesFeaturizer_float_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_float_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_float_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MissingDummiesFeaturizer_float_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_float_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int8_t> results;
+    std::vector<std::int8_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int8_t result;
+        std::int8_t result;
 
-        REQUIRE(MissingDummiesFeaturizer_float_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<float>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<float>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_float_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::float_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::float_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -939,24 +939,24 @@ void MissingDummiesFeaturizer_float_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MissingDummiesFeaturizer_float_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_float_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  MissingDummiesFeaturizer <double_t> */
+/* |  MissingDummiesFeaturizer <double> */
 template <typename VectorInputT>
-void MissingDummiesFeaturizer_double_t_Test(
+void MissingDummiesFeaturizer_double_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int8_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int8_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    MissingDummiesFeaturizer_double_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    MissingDummiesFeaturizer_double_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_double_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_double_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -967,7 +967,7 @@ void MissingDummiesFeaturizer_double_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(MissingDummiesFeaturizer_double_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_double_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -976,7 +976,7 @@ void MissingDummiesFeaturizer_double_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(MissingDummiesFeaturizer_double_t_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<double>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<double>::GetNullableValue(input), &result, &pErrorInfo));
+            REQUIRE(MissingDummiesFeaturizer_double_Fit(pEstimatorHandle, Microsoft::Featurizer::Traits<std::double_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::double_t>::GetNullableValue(input), &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -986,7 +986,7 @@ void MissingDummiesFeaturizer_double_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(MissingDummiesFeaturizer_double_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(MissingDummiesFeaturizer_double_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -994,7 +994,7 @@ void MissingDummiesFeaturizer_double_t_Test(
         }
     }
 
-    MissingDummiesFeaturizer_double_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    MissingDummiesFeaturizer_double_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -1002,31 +1002,31 @@ void MissingDummiesFeaturizer_double_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(MissingDummiesFeaturizer_double_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_double_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    MissingDummiesFeaturizer_double_t_TransformerHandle * pTransformerHandle(nullptr);
+    MissingDummiesFeaturizer_double_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(MissingDummiesFeaturizer_double_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_double_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(MissingDummiesFeaturizer_double_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_double_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int8_t> results;
+    std::vector<std::int8_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int8_t result;
+        std::int8_t result;
 
-        REQUIRE(MissingDummiesFeaturizer_double_t_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<double>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<double>::GetNullableValue(input), &result, &pErrorInfo));
+        REQUIRE(MissingDummiesFeaturizer_double_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::double_t>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<std::double_t>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -1043,7 +1043,7 @@ void MissingDummiesFeaturizer_double_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(MissingDummiesFeaturizer_double_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(MissingDummiesFeaturizer_double_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
@@ -1053,7 +1053,7 @@ template <typename VectorInputT>
 void MissingDummiesFeaturizer_bool_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int8_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int8_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
@@ -1123,12 +1123,12 @@ void MissingDummiesFeaturizer_bool_Test(
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int8_t> results;
+    std::vector<std::int8_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int8_t result;
+        std::int8_t result;
 
         REQUIRE(MissingDummiesFeaturizer_bool_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<bool>::IsNull(input) ? nullptr : &Microsoft::Featurizer::Traits<bool>::GetNullableValue(input), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
@@ -1157,7 +1157,7 @@ template <typename VectorInputT>
 void MissingDummiesFeaturizer_string_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<int8_t> const &)> const &verify_func
+    std::function<bool (std::vector<std::int8_t> const &)> const &verify_func
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
@@ -1227,12 +1227,12 @@ void MissingDummiesFeaturizer_string_Test(
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<int8_t> results;
+    std::vector<std::int8_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        int8_t result;
+        std::int8_t result;
 
         REQUIRE(MissingDummiesFeaturizer_string_Transform(pTransformerHandle, Microsoft::Featurizer::Traits<std::string>::IsNull(input) ? nullptr : input->c_str(), &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);

--- a/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_OneHotEncoderFeaturizer.h
+++ b/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_OneHotEncoderFeaturizer.h
@@ -8,9 +8,9 @@
 #include "Traits.h"
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <int8_t> */
+/* |  OneHotEncoderFeaturizer <int8> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void OneHotEncoderFeaturizer_int8_t_Test(
+void OneHotEncoderFeaturizer_int8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<OneHotStruct> const &)> const &verify_func,
@@ -19,9 +19,9 @@ void OneHotEncoderFeaturizer_int8_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    OneHotEncoderFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    OneHotEncoderFeaturizer_int8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_int8_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int8_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -32,7 +32,7 @@ void OneHotEncoderFeaturizer_int8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(OneHotEncoderFeaturizer_int8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_int8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -41,7 +41,7 @@ void OneHotEncoderFeaturizer_int8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(OneHotEncoderFeaturizer_int8_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_int8_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -51,7 +51,7 @@ void OneHotEncoderFeaturizer_int8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(OneHotEncoderFeaturizer_int8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(OneHotEncoderFeaturizer_int8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -59,7 +59,7 @@ void OneHotEncoderFeaturizer_int8_t_Test(
         }
     }
 
-    OneHotEncoderFeaturizer_int8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    OneHotEncoderFeaturizer_int8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -67,20 +67,20 @@ void OneHotEncoderFeaturizer_int8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(OneHotEncoderFeaturizer_int8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_int8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    OneHotEncoderFeaturizer_int8_t_TransformerHandle * pTransformerHandle(nullptr);
+    OneHotEncoderFeaturizer_int8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_int8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(OneHotEncoderFeaturizer_int8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -91,7 +91,7 @@ void OneHotEncoderFeaturizer_int8_t_Test(
     for(auto const & input : inference_input) {
         OneHotStruct result;
 
-        REQUIRE(OneHotEncoderFeaturizer_int8_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_int8_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -106,19 +106,19 @@ void OneHotEncoderFeaturizer_int8_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(OneHotEncoderFeaturizer_int8_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_int8_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(OneHotEncoderFeaturizer_int8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <int16_t> */
+/* |  OneHotEncoderFeaturizer <int16> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void OneHotEncoderFeaturizer_int16_t_Test(
+void OneHotEncoderFeaturizer_int16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<OneHotStruct> const &)> const &verify_func,
@@ -127,9 +127,9 @@ void OneHotEncoderFeaturizer_int16_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    OneHotEncoderFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    OneHotEncoderFeaturizer_int16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_int16_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int16_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -140,7 +140,7 @@ void OneHotEncoderFeaturizer_int16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(OneHotEncoderFeaturizer_int16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_int16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -149,7 +149,7 @@ void OneHotEncoderFeaturizer_int16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(OneHotEncoderFeaturizer_int16_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_int16_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -159,7 +159,7 @@ void OneHotEncoderFeaturizer_int16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(OneHotEncoderFeaturizer_int16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(OneHotEncoderFeaturizer_int16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -167,7 +167,7 @@ void OneHotEncoderFeaturizer_int16_t_Test(
         }
     }
 
-    OneHotEncoderFeaturizer_int16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    OneHotEncoderFeaturizer_int16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -175,20 +175,20 @@ void OneHotEncoderFeaturizer_int16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(OneHotEncoderFeaturizer_int16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_int16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    OneHotEncoderFeaturizer_int16_t_TransformerHandle * pTransformerHandle(nullptr);
+    OneHotEncoderFeaturizer_int16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_int16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(OneHotEncoderFeaturizer_int16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -199,7 +199,7 @@ void OneHotEncoderFeaturizer_int16_t_Test(
     for(auto const & input : inference_input) {
         OneHotStruct result;
 
-        REQUIRE(OneHotEncoderFeaturizer_int16_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_int16_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -214,19 +214,19 @@ void OneHotEncoderFeaturizer_int16_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(OneHotEncoderFeaturizer_int16_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_int16_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(OneHotEncoderFeaturizer_int16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <int32_t> */
+/* |  OneHotEncoderFeaturizer <int32> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void OneHotEncoderFeaturizer_int32_t_Test(
+void OneHotEncoderFeaturizer_int32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<OneHotStruct> const &)> const &verify_func,
@@ -235,9 +235,9 @@ void OneHotEncoderFeaturizer_int32_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    OneHotEncoderFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    OneHotEncoderFeaturizer_int32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_int32_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int32_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -248,7 +248,7 @@ void OneHotEncoderFeaturizer_int32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(OneHotEncoderFeaturizer_int32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_int32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -257,7 +257,7 @@ void OneHotEncoderFeaturizer_int32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(OneHotEncoderFeaturizer_int32_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_int32_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -267,7 +267,7 @@ void OneHotEncoderFeaturizer_int32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(OneHotEncoderFeaturizer_int32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(OneHotEncoderFeaturizer_int32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -275,7 +275,7 @@ void OneHotEncoderFeaturizer_int32_t_Test(
         }
     }
 
-    OneHotEncoderFeaturizer_int32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    OneHotEncoderFeaturizer_int32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -283,20 +283,20 @@ void OneHotEncoderFeaturizer_int32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(OneHotEncoderFeaturizer_int32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_int32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    OneHotEncoderFeaturizer_int32_t_TransformerHandle * pTransformerHandle(nullptr);
+    OneHotEncoderFeaturizer_int32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_int32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(OneHotEncoderFeaturizer_int32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -307,7 +307,7 @@ void OneHotEncoderFeaturizer_int32_t_Test(
     for(auto const & input : inference_input) {
         OneHotStruct result;
 
-        REQUIRE(OneHotEncoderFeaturizer_int32_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_int32_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -322,19 +322,19 @@ void OneHotEncoderFeaturizer_int32_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(OneHotEncoderFeaturizer_int32_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_int32_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(OneHotEncoderFeaturizer_int32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <int64_t> */
+/* |  OneHotEncoderFeaturizer <int64> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void OneHotEncoderFeaturizer_int64_t_Test(
+void OneHotEncoderFeaturizer_int64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<OneHotStruct> const &)> const &verify_func,
@@ -343,9 +343,9 @@ void OneHotEncoderFeaturizer_int64_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    OneHotEncoderFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    OneHotEncoderFeaturizer_int64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_int64_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int64_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -356,7 +356,7 @@ void OneHotEncoderFeaturizer_int64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(OneHotEncoderFeaturizer_int64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_int64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -365,7 +365,7 @@ void OneHotEncoderFeaturizer_int64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(OneHotEncoderFeaturizer_int64_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_int64_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -375,7 +375,7 @@ void OneHotEncoderFeaturizer_int64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(OneHotEncoderFeaturizer_int64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(OneHotEncoderFeaturizer_int64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -383,7 +383,7 @@ void OneHotEncoderFeaturizer_int64_t_Test(
         }
     }
 
-    OneHotEncoderFeaturizer_int64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    OneHotEncoderFeaturizer_int64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -391,20 +391,20 @@ void OneHotEncoderFeaturizer_int64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(OneHotEncoderFeaturizer_int64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_int64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    OneHotEncoderFeaturizer_int64_t_TransformerHandle * pTransformerHandle(nullptr);
+    OneHotEncoderFeaturizer_int64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_int64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(OneHotEncoderFeaturizer_int64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -415,7 +415,7 @@ void OneHotEncoderFeaturizer_int64_t_Test(
     for(auto const & input : inference_input) {
         OneHotStruct result;
 
-        REQUIRE(OneHotEncoderFeaturizer_int64_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_int64_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -430,19 +430,19 @@ void OneHotEncoderFeaturizer_int64_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(OneHotEncoderFeaturizer_int64_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_int64_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(OneHotEncoderFeaturizer_int64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_int64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <uint8_t> */
+/* |  OneHotEncoderFeaturizer <uint8> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void OneHotEncoderFeaturizer_uint8_t_Test(
+void OneHotEncoderFeaturizer_uint8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<OneHotStruct> const &)> const &verify_func,
@@ -451,9 +451,9 @@ void OneHotEncoderFeaturizer_uint8_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    OneHotEncoderFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    OneHotEncoderFeaturizer_uint8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_uint8_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint8_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -464,7 +464,7 @@ void OneHotEncoderFeaturizer_uint8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(OneHotEncoderFeaturizer_uint8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_uint8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -473,7 +473,7 @@ void OneHotEncoderFeaturizer_uint8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(OneHotEncoderFeaturizer_uint8_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_uint8_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -483,7 +483,7 @@ void OneHotEncoderFeaturizer_uint8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(OneHotEncoderFeaturizer_uint8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(OneHotEncoderFeaturizer_uint8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -491,7 +491,7 @@ void OneHotEncoderFeaturizer_uint8_t_Test(
         }
     }
 
-    OneHotEncoderFeaturizer_uint8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    OneHotEncoderFeaturizer_uint8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -499,20 +499,20 @@ void OneHotEncoderFeaturizer_uint8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(OneHotEncoderFeaturizer_uint8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_uint8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    OneHotEncoderFeaturizer_uint8_t_TransformerHandle * pTransformerHandle(nullptr);
+    OneHotEncoderFeaturizer_uint8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_uint8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(OneHotEncoderFeaturizer_uint8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -523,7 +523,7 @@ void OneHotEncoderFeaturizer_uint8_t_Test(
     for(auto const & input : inference_input) {
         OneHotStruct result;
 
-        REQUIRE(OneHotEncoderFeaturizer_uint8_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_uint8_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -538,19 +538,19 @@ void OneHotEncoderFeaturizer_uint8_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(OneHotEncoderFeaturizer_uint8_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_uint8_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(OneHotEncoderFeaturizer_uint8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <uint16_t> */
+/* |  OneHotEncoderFeaturizer <uint16> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void OneHotEncoderFeaturizer_uint16_t_Test(
+void OneHotEncoderFeaturizer_uint16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<OneHotStruct> const &)> const &verify_func,
@@ -559,9 +559,9 @@ void OneHotEncoderFeaturizer_uint16_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    OneHotEncoderFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    OneHotEncoderFeaturizer_uint16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_uint16_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint16_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -572,7 +572,7 @@ void OneHotEncoderFeaturizer_uint16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(OneHotEncoderFeaturizer_uint16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_uint16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -581,7 +581,7 @@ void OneHotEncoderFeaturizer_uint16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(OneHotEncoderFeaturizer_uint16_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_uint16_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -591,7 +591,7 @@ void OneHotEncoderFeaturizer_uint16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(OneHotEncoderFeaturizer_uint16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(OneHotEncoderFeaturizer_uint16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -599,7 +599,7 @@ void OneHotEncoderFeaturizer_uint16_t_Test(
         }
     }
 
-    OneHotEncoderFeaturizer_uint16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    OneHotEncoderFeaturizer_uint16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -607,20 +607,20 @@ void OneHotEncoderFeaturizer_uint16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(OneHotEncoderFeaturizer_uint16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_uint16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    OneHotEncoderFeaturizer_uint16_t_TransformerHandle * pTransformerHandle(nullptr);
+    OneHotEncoderFeaturizer_uint16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_uint16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(OneHotEncoderFeaturizer_uint16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -631,7 +631,7 @@ void OneHotEncoderFeaturizer_uint16_t_Test(
     for(auto const & input : inference_input) {
         OneHotStruct result;
 
-        REQUIRE(OneHotEncoderFeaturizer_uint16_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_uint16_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -646,19 +646,19 @@ void OneHotEncoderFeaturizer_uint16_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(OneHotEncoderFeaturizer_uint16_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_uint16_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(OneHotEncoderFeaturizer_uint16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <uint32_t> */
+/* |  OneHotEncoderFeaturizer <uint32> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void OneHotEncoderFeaturizer_uint32_t_Test(
+void OneHotEncoderFeaturizer_uint32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<OneHotStruct> const &)> const &verify_func,
@@ -667,9 +667,9 @@ void OneHotEncoderFeaturizer_uint32_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    OneHotEncoderFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    OneHotEncoderFeaturizer_uint32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_uint32_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint32_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -680,7 +680,7 @@ void OneHotEncoderFeaturizer_uint32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(OneHotEncoderFeaturizer_uint32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_uint32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -689,7 +689,7 @@ void OneHotEncoderFeaturizer_uint32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(OneHotEncoderFeaturizer_uint32_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_uint32_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -699,7 +699,7 @@ void OneHotEncoderFeaturizer_uint32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(OneHotEncoderFeaturizer_uint32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(OneHotEncoderFeaturizer_uint32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -707,7 +707,7 @@ void OneHotEncoderFeaturizer_uint32_t_Test(
         }
     }
 
-    OneHotEncoderFeaturizer_uint32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    OneHotEncoderFeaturizer_uint32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -715,20 +715,20 @@ void OneHotEncoderFeaturizer_uint32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(OneHotEncoderFeaturizer_uint32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_uint32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    OneHotEncoderFeaturizer_uint32_t_TransformerHandle * pTransformerHandle(nullptr);
+    OneHotEncoderFeaturizer_uint32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_uint32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(OneHotEncoderFeaturizer_uint32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -739,7 +739,7 @@ void OneHotEncoderFeaturizer_uint32_t_Test(
     for(auto const & input : inference_input) {
         OneHotStruct result;
 
-        REQUIRE(OneHotEncoderFeaturizer_uint32_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_uint32_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -754,19 +754,19 @@ void OneHotEncoderFeaturizer_uint32_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(OneHotEncoderFeaturizer_uint32_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_uint32_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(OneHotEncoderFeaturizer_uint32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <uint64_t> */
+/* |  OneHotEncoderFeaturizer <uint64> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void OneHotEncoderFeaturizer_uint64_t_Test(
+void OneHotEncoderFeaturizer_uint64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<OneHotStruct> const &)> const &verify_func,
@@ -775,9 +775,9 @@ void OneHotEncoderFeaturizer_uint64_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    OneHotEncoderFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    OneHotEncoderFeaturizer_uint64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_uint64_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint64_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -788,7 +788,7 @@ void OneHotEncoderFeaturizer_uint64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(OneHotEncoderFeaturizer_uint64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_uint64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -797,7 +797,7 @@ void OneHotEncoderFeaturizer_uint64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(OneHotEncoderFeaturizer_uint64_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_uint64_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -807,7 +807,7 @@ void OneHotEncoderFeaturizer_uint64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(OneHotEncoderFeaturizer_uint64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(OneHotEncoderFeaturizer_uint64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -815,7 +815,7 @@ void OneHotEncoderFeaturizer_uint64_t_Test(
         }
     }
 
-    OneHotEncoderFeaturizer_uint64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    OneHotEncoderFeaturizer_uint64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -823,20 +823,20 @@ void OneHotEncoderFeaturizer_uint64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(OneHotEncoderFeaturizer_uint64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_uint64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    OneHotEncoderFeaturizer_uint64_t_TransformerHandle * pTransformerHandle(nullptr);
+    OneHotEncoderFeaturizer_uint64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_uint64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(OneHotEncoderFeaturizer_uint64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -847,7 +847,7 @@ void OneHotEncoderFeaturizer_uint64_t_Test(
     for(auto const & input : inference_input) {
         OneHotStruct result;
 
-        REQUIRE(OneHotEncoderFeaturizer_uint64_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_uint64_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -862,19 +862,19 @@ void OneHotEncoderFeaturizer_uint64_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(OneHotEncoderFeaturizer_uint64_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_uint64_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(OneHotEncoderFeaturizer_uint64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_uint64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <float_t> */
+/* |  OneHotEncoderFeaturizer <float> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void OneHotEncoderFeaturizer_float_t_Test(
+void OneHotEncoderFeaturizer_float_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<OneHotStruct> const &)> const &verify_func,
@@ -883,9 +883,9 @@ void OneHotEncoderFeaturizer_float_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    OneHotEncoderFeaturizer_float_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    OneHotEncoderFeaturizer_float_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_float_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_float_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -896,7 +896,7 @@ void OneHotEncoderFeaturizer_float_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(OneHotEncoderFeaturizer_float_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_float_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -905,7 +905,7 @@ void OneHotEncoderFeaturizer_float_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(OneHotEncoderFeaturizer_float_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_float_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -915,7 +915,7 @@ void OneHotEncoderFeaturizer_float_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(OneHotEncoderFeaturizer_float_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(OneHotEncoderFeaturizer_float_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -923,7 +923,7 @@ void OneHotEncoderFeaturizer_float_t_Test(
         }
     }
 
-    OneHotEncoderFeaturizer_float_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    OneHotEncoderFeaturizer_float_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -931,20 +931,20 @@ void OneHotEncoderFeaturizer_float_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(OneHotEncoderFeaturizer_float_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_float_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    OneHotEncoderFeaturizer_float_t_TransformerHandle * pTransformerHandle(nullptr);
+    OneHotEncoderFeaturizer_float_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_float_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_float_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(OneHotEncoderFeaturizer_float_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_float_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -955,7 +955,7 @@ void OneHotEncoderFeaturizer_float_t_Test(
     for(auto const & input : inference_input) {
         OneHotStruct result;
 
-        REQUIRE(OneHotEncoderFeaturizer_float_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_float_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -970,19 +970,19 @@ void OneHotEncoderFeaturizer_float_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(OneHotEncoderFeaturizer_float_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_float_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(OneHotEncoderFeaturizer_float_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_float_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  OneHotEncoderFeaturizer <double_t> */
+/* |  OneHotEncoderFeaturizer <double> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void OneHotEncoderFeaturizer_double_t_Test(
+void OneHotEncoderFeaturizer_double_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<OneHotStruct> const &)> const &verify_func,
@@ -991,9 +991,9 @@ void OneHotEncoderFeaturizer_double_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    OneHotEncoderFeaturizer_double_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    OneHotEncoderFeaturizer_double_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_double_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_double_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -1004,7 +1004,7 @@ void OneHotEncoderFeaturizer_double_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(OneHotEncoderFeaturizer_double_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_double_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -1013,7 +1013,7 @@ void OneHotEncoderFeaturizer_double_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(OneHotEncoderFeaturizer_double_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(OneHotEncoderFeaturizer_double_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -1023,7 +1023,7 @@ void OneHotEncoderFeaturizer_double_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(OneHotEncoderFeaturizer_double_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(OneHotEncoderFeaturizer_double_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -1031,7 +1031,7 @@ void OneHotEncoderFeaturizer_double_t_Test(
         }
     }
 
-    OneHotEncoderFeaturizer_double_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    OneHotEncoderFeaturizer_double_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -1039,20 +1039,20 @@ void OneHotEncoderFeaturizer_double_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(OneHotEncoderFeaturizer_double_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_double_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    OneHotEncoderFeaturizer_double_t_TransformerHandle * pTransformerHandle(nullptr);
+    OneHotEncoderFeaturizer_double_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(OneHotEncoderFeaturizer_double_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_double_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(OneHotEncoderFeaturizer_double_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_double_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -1063,7 +1063,7 @@ void OneHotEncoderFeaturizer_double_t_Test(
     for(auto const & input : inference_input) {
         OneHotStruct result;
 
-        REQUIRE(OneHotEncoderFeaturizer_double_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_double_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -1078,12 +1078,12 @@ void OneHotEncoderFeaturizer_double_t_Test(
     REQUIRE(verify_func(results));
 
     for(auto & result: results) {
-        REQUIRE(OneHotEncoderFeaturizer_double_t_DestroyTransformedData(&result, &pErrorInfo));
+        REQUIRE(OneHotEncoderFeaturizer_double_DestroyTransformedData(&result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
     // Destroy the transformer
-    REQUIRE(OneHotEncoderFeaturizer_double_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(OneHotEncoderFeaturizer_double_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 

--- a/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_RobustScalarFeaturizer.h
+++ b/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_RobustScalarFeaturizer.h
@@ -8,20 +8,20 @@
 #include "Traits.h"
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <int8_t> */
+/* |  RobustScalarFeaturizer <int8> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void RobustScalarFeaturizer_int8_t_Test(
+void RobustScalarFeaturizer_int8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<float> const &)> const &verify_func,
+    std::function<bool (std::vector<std::float_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    RobustScalarFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    RobustScalarFeaturizer_int8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_int8_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int8_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -32,7 +32,7 @@ void RobustScalarFeaturizer_int8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(RobustScalarFeaturizer_int8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_int8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -41,7 +41,7 @@ void RobustScalarFeaturizer_int8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(RobustScalarFeaturizer_int8_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_int8_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -51,7 +51,7 @@ void RobustScalarFeaturizer_int8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(RobustScalarFeaturizer_int8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(RobustScalarFeaturizer_int8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -59,7 +59,7 @@ void RobustScalarFeaturizer_int8_t_Test(
         }
     }
 
-    RobustScalarFeaturizer_int8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    RobustScalarFeaturizer_int8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -67,31 +67,31 @@ void RobustScalarFeaturizer_int8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(RobustScalarFeaturizer_int8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_int8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    RobustScalarFeaturizer_int8_t_TransformerHandle * pTransformerHandle(nullptr);
+    RobustScalarFeaturizer_int8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_int8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(RobustScalarFeaturizer_int8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<float> results;
+    std::vector<std::float_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        float result;
+        std::float_t result;
 
-        REQUIRE(RobustScalarFeaturizer_int8_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_int8_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -108,25 +108,25 @@ void RobustScalarFeaturizer_int8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(RobustScalarFeaturizer_int8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <int16_t> */
+/* |  RobustScalarFeaturizer <int16> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void RobustScalarFeaturizer_int16_t_Test(
+void RobustScalarFeaturizer_int16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<float> const &)> const &verify_func,
+    std::function<bool (std::vector<std::float_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    RobustScalarFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    RobustScalarFeaturizer_int16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_int16_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int16_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -137,7 +137,7 @@ void RobustScalarFeaturizer_int16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(RobustScalarFeaturizer_int16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_int16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -146,7 +146,7 @@ void RobustScalarFeaturizer_int16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(RobustScalarFeaturizer_int16_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_int16_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -156,7 +156,7 @@ void RobustScalarFeaturizer_int16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(RobustScalarFeaturizer_int16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(RobustScalarFeaturizer_int16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -164,7 +164,7 @@ void RobustScalarFeaturizer_int16_t_Test(
         }
     }
 
-    RobustScalarFeaturizer_int16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    RobustScalarFeaturizer_int16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -172,31 +172,31 @@ void RobustScalarFeaturizer_int16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(RobustScalarFeaturizer_int16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_int16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    RobustScalarFeaturizer_int16_t_TransformerHandle * pTransformerHandle(nullptr);
+    RobustScalarFeaturizer_int16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_int16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(RobustScalarFeaturizer_int16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<float> results;
+    std::vector<std::float_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        float result;
+        std::float_t result;
 
-        REQUIRE(RobustScalarFeaturizer_int16_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_int16_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -213,25 +213,25 @@ void RobustScalarFeaturizer_int16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(RobustScalarFeaturizer_int16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <uint8_t> */
+/* |  RobustScalarFeaturizer <uint8> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void RobustScalarFeaturizer_uint8_t_Test(
+void RobustScalarFeaturizer_uint8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<float> const &)> const &verify_func,
+    std::function<bool (std::vector<std::float_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    RobustScalarFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    RobustScalarFeaturizer_uint8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_uint8_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint8_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -242,7 +242,7 @@ void RobustScalarFeaturizer_uint8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(RobustScalarFeaturizer_uint8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_uint8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -251,7 +251,7 @@ void RobustScalarFeaturizer_uint8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(RobustScalarFeaturizer_uint8_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_uint8_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -261,7 +261,7 @@ void RobustScalarFeaturizer_uint8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(RobustScalarFeaturizer_uint8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(RobustScalarFeaturizer_uint8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -269,7 +269,7 @@ void RobustScalarFeaturizer_uint8_t_Test(
         }
     }
 
-    RobustScalarFeaturizer_uint8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    RobustScalarFeaturizer_uint8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -277,31 +277,31 @@ void RobustScalarFeaturizer_uint8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(RobustScalarFeaturizer_uint8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_uint8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    RobustScalarFeaturizer_uint8_t_TransformerHandle * pTransformerHandle(nullptr);
+    RobustScalarFeaturizer_uint8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_uint8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(RobustScalarFeaturizer_uint8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<float> results;
+    std::vector<std::float_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        float result;
+        std::float_t result;
 
-        REQUIRE(RobustScalarFeaturizer_uint8_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_uint8_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -318,25 +318,25 @@ void RobustScalarFeaturizer_uint8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(RobustScalarFeaturizer_uint8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <uint16_t> */
+/* |  RobustScalarFeaturizer <uint16> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void RobustScalarFeaturizer_uint16_t_Test(
+void RobustScalarFeaturizer_uint16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<float> const &)> const &verify_func,
+    std::function<bool (std::vector<std::float_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    RobustScalarFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    RobustScalarFeaturizer_uint16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_uint16_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint16_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -347,7 +347,7 @@ void RobustScalarFeaturizer_uint16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(RobustScalarFeaturizer_uint16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_uint16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -356,7 +356,7 @@ void RobustScalarFeaturizer_uint16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(RobustScalarFeaturizer_uint16_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_uint16_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -366,7 +366,7 @@ void RobustScalarFeaturizer_uint16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(RobustScalarFeaturizer_uint16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(RobustScalarFeaturizer_uint16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -374,7 +374,7 @@ void RobustScalarFeaturizer_uint16_t_Test(
         }
     }
 
-    RobustScalarFeaturizer_uint16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    RobustScalarFeaturizer_uint16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -382,31 +382,31 @@ void RobustScalarFeaturizer_uint16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(RobustScalarFeaturizer_uint16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_uint16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    RobustScalarFeaturizer_uint16_t_TransformerHandle * pTransformerHandle(nullptr);
+    RobustScalarFeaturizer_uint16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_uint16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(RobustScalarFeaturizer_uint16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<float> results;
+    std::vector<std::float_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        float result;
+        std::float_t result;
 
-        REQUIRE(RobustScalarFeaturizer_uint16_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_uint16_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -423,25 +423,25 @@ void RobustScalarFeaturizer_uint16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(RobustScalarFeaturizer_uint16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <float_t> */
+/* |  RobustScalarFeaturizer <float> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void RobustScalarFeaturizer_float_t_Test(
+void RobustScalarFeaturizer_float_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<float> const &)> const &verify_func,
+    std::function<bool (std::vector<std::float_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    RobustScalarFeaturizer_float_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    RobustScalarFeaturizer_float_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_float_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_float_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -452,7 +452,7 @@ void RobustScalarFeaturizer_float_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(RobustScalarFeaturizer_float_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_float_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -461,7 +461,7 @@ void RobustScalarFeaturizer_float_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(RobustScalarFeaturizer_float_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_float_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -471,7 +471,7 @@ void RobustScalarFeaturizer_float_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(RobustScalarFeaturizer_float_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(RobustScalarFeaturizer_float_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -479,7 +479,7 @@ void RobustScalarFeaturizer_float_t_Test(
         }
     }
 
-    RobustScalarFeaturizer_float_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    RobustScalarFeaturizer_float_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -487,31 +487,31 @@ void RobustScalarFeaturizer_float_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(RobustScalarFeaturizer_float_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_float_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    RobustScalarFeaturizer_float_t_TransformerHandle * pTransformerHandle(nullptr);
+    RobustScalarFeaturizer_float_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_float_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_float_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(RobustScalarFeaturizer_float_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_float_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<float> results;
+    std::vector<std::float_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        float result;
+        std::float_t result;
 
-        REQUIRE(RobustScalarFeaturizer_float_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_float_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -528,25 +528,25 @@ void RobustScalarFeaturizer_float_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(RobustScalarFeaturizer_float_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_float_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <int32_t> */
+/* |  RobustScalarFeaturizer <int32> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void RobustScalarFeaturizer_int32_t_Test(
+void RobustScalarFeaturizer_int32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func,
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    RobustScalarFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    RobustScalarFeaturizer_int32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_int32_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int32_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -557,7 +557,7 @@ void RobustScalarFeaturizer_int32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(RobustScalarFeaturizer_int32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_int32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -566,7 +566,7 @@ void RobustScalarFeaturizer_int32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(RobustScalarFeaturizer_int32_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_int32_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -576,7 +576,7 @@ void RobustScalarFeaturizer_int32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(RobustScalarFeaturizer_int32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(RobustScalarFeaturizer_int32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -584,7 +584,7 @@ void RobustScalarFeaturizer_int32_t_Test(
         }
     }
 
-    RobustScalarFeaturizer_int32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    RobustScalarFeaturizer_int32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -592,31 +592,31 @@ void RobustScalarFeaturizer_int32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(RobustScalarFeaturizer_int32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_int32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    RobustScalarFeaturizer_int32_t_TransformerHandle * pTransformerHandle(nullptr);
+    RobustScalarFeaturizer_int32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_int32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(RobustScalarFeaturizer_int32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(RobustScalarFeaturizer_int32_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_int32_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -633,25 +633,25 @@ void RobustScalarFeaturizer_int32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(RobustScalarFeaturizer_int32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <int64_t> */
+/* |  RobustScalarFeaturizer <int64> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void RobustScalarFeaturizer_int64_t_Test(
+void RobustScalarFeaturizer_int64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func,
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    RobustScalarFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    RobustScalarFeaturizer_int64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_int64_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int64_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -662,7 +662,7 @@ void RobustScalarFeaturizer_int64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(RobustScalarFeaturizer_int64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_int64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -671,7 +671,7 @@ void RobustScalarFeaturizer_int64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(RobustScalarFeaturizer_int64_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_int64_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -681,7 +681,7 @@ void RobustScalarFeaturizer_int64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(RobustScalarFeaturizer_int64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(RobustScalarFeaturizer_int64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -689,7 +689,7 @@ void RobustScalarFeaturizer_int64_t_Test(
         }
     }
 
-    RobustScalarFeaturizer_int64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    RobustScalarFeaturizer_int64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -697,31 +697,31 @@ void RobustScalarFeaturizer_int64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(RobustScalarFeaturizer_int64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_int64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    RobustScalarFeaturizer_int64_t_TransformerHandle * pTransformerHandle(nullptr);
+    RobustScalarFeaturizer_int64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_int64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(RobustScalarFeaturizer_int64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(RobustScalarFeaturizer_int64_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_int64_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -738,25 +738,25 @@ void RobustScalarFeaturizer_int64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(RobustScalarFeaturizer_int64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <uint32_t> */
+/* |  RobustScalarFeaturizer <uint32> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void RobustScalarFeaturizer_uint32_t_Test(
+void RobustScalarFeaturizer_uint32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func,
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    RobustScalarFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    RobustScalarFeaturizer_uint32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_uint32_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint32_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -767,7 +767,7 @@ void RobustScalarFeaturizer_uint32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(RobustScalarFeaturizer_uint32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_uint32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -776,7 +776,7 @@ void RobustScalarFeaturizer_uint32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(RobustScalarFeaturizer_uint32_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_uint32_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -786,7 +786,7 @@ void RobustScalarFeaturizer_uint32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(RobustScalarFeaturizer_uint32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(RobustScalarFeaturizer_uint32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -794,7 +794,7 @@ void RobustScalarFeaturizer_uint32_t_Test(
         }
     }
 
-    RobustScalarFeaturizer_uint32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    RobustScalarFeaturizer_uint32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -802,31 +802,31 @@ void RobustScalarFeaturizer_uint32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(RobustScalarFeaturizer_uint32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_uint32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    RobustScalarFeaturizer_uint32_t_TransformerHandle * pTransformerHandle(nullptr);
+    RobustScalarFeaturizer_uint32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_uint32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(RobustScalarFeaturizer_uint32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(RobustScalarFeaturizer_uint32_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_uint32_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -843,25 +843,25 @@ void RobustScalarFeaturizer_uint32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(RobustScalarFeaturizer_uint32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <uint64_t> */
+/* |  RobustScalarFeaturizer <uint64> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void RobustScalarFeaturizer_uint64_t_Test(
+void RobustScalarFeaturizer_uint64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func,
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    RobustScalarFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    RobustScalarFeaturizer_uint64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_uint64_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint64_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -872,7 +872,7 @@ void RobustScalarFeaturizer_uint64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(RobustScalarFeaturizer_uint64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_uint64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -881,7 +881,7 @@ void RobustScalarFeaturizer_uint64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(RobustScalarFeaturizer_uint64_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_uint64_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -891,7 +891,7 @@ void RobustScalarFeaturizer_uint64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(RobustScalarFeaturizer_uint64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(RobustScalarFeaturizer_uint64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -899,7 +899,7 @@ void RobustScalarFeaturizer_uint64_t_Test(
         }
     }
 
-    RobustScalarFeaturizer_uint64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    RobustScalarFeaturizer_uint64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -907,31 +907,31 @@ void RobustScalarFeaturizer_uint64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(RobustScalarFeaturizer_uint64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_uint64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    RobustScalarFeaturizer_uint64_t_TransformerHandle * pTransformerHandle(nullptr);
+    RobustScalarFeaturizer_uint64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_uint64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(RobustScalarFeaturizer_uint64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(RobustScalarFeaturizer_uint64_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_uint64_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -948,25 +948,25 @@ void RobustScalarFeaturizer_uint64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(RobustScalarFeaturizer_uint64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_uint64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  RobustScalarFeaturizer <double_t> */
+/* |  RobustScalarFeaturizer <double> */
 template <typename VectorInputT, typename... ConstructorArgTs>
-void RobustScalarFeaturizer_double_t_Test(
+void RobustScalarFeaturizer_double_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
-    std::function<bool (std::vector<double> const &)> const &verify_func,
+    std::function<bool (std::vector<std::double_t> const &)> const &verify_func,
     ConstructorArgTs &&... constructor_args
 ) {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    RobustScalarFeaturizer_double_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    RobustScalarFeaturizer_double_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_double_t_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_double_CreateEstimator(std::forward<ConstructorArgTs>(constructor_args)..., &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -977,7 +977,7 @@ void RobustScalarFeaturizer_double_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(RobustScalarFeaturizer_double_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_double_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -986,7 +986,7 @@ void RobustScalarFeaturizer_double_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(RobustScalarFeaturizer_double_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(RobustScalarFeaturizer_double_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -996,7 +996,7 @@ void RobustScalarFeaturizer_double_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(RobustScalarFeaturizer_double_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(RobustScalarFeaturizer_double_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -1004,7 +1004,7 @@ void RobustScalarFeaturizer_double_t_Test(
         }
     }
 
-    RobustScalarFeaturizer_double_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    RobustScalarFeaturizer_double_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -1012,31 +1012,31 @@ void RobustScalarFeaturizer_double_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(RobustScalarFeaturizer_double_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_double_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    RobustScalarFeaturizer_double_t_TransformerHandle * pTransformerHandle(nullptr);
+    RobustScalarFeaturizer_double_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_double_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_double_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(RobustScalarFeaturizer_double_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_double_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
-    std::vector<double> results;
+    std::vector<std::double_t> results;
 
     results.reserve(inference_input.size());
 
     for(auto const & input : inference_input) {
-        double result;
+        std::double_t result;
 
-        REQUIRE(RobustScalarFeaturizer_double_t_Transform(pTransformerHandle, input, &result, &pErrorInfo));
+        REQUIRE(RobustScalarFeaturizer_double_Transform(pTransformerHandle, input, &result, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -1053,7 +1053,7 @@ void RobustScalarFeaturizer_double_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(RobustScalarFeaturizer_double_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_double_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 

--- a/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_StringFeaturizer.h
+++ b/src/SharedLibrary/IntegrationTests/GeneratedCode/SharedLibraryTests_StringFeaturizer.h
@@ -8,9 +8,9 @@
 #include "Traits.h"
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <int8_t> */
+/* |  StringFeaturizer <int8> */
 template <typename VectorInputT>
-void StringFeaturizer_int8_t_Test(
+void StringFeaturizer_int8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<std::string> const &)> const &verify_func
@@ -18,9 +18,9 @@ void StringFeaturizer_int8_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    StringFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    StringFeaturizer_int8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_int8_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int8_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -31,7 +31,7 @@ void StringFeaturizer_int8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(StringFeaturizer_int8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(StringFeaturizer_int8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -40,7 +40,7 @@ void StringFeaturizer_int8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(StringFeaturizer_int8_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(StringFeaturizer_int8_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -50,7 +50,7 @@ void StringFeaturizer_int8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(StringFeaturizer_int8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(StringFeaturizer_int8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -58,7 +58,7 @@ void StringFeaturizer_int8_t_Test(
         }
     }
 
-    StringFeaturizer_int8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    StringFeaturizer_int8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -66,20 +66,20 @@ void StringFeaturizer_int8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(StringFeaturizer_int8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(StringFeaturizer_int8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    StringFeaturizer_int8_t_TransformerHandle * pTransformerHandle(nullptr);
+    StringFeaturizer_int8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_int8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(StringFeaturizer_int8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -92,7 +92,7 @@ void StringFeaturizer_int8_t_Test(
         std::size_t result_items(0);
 
 
-        REQUIRE(StringFeaturizer_int8_t_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_int8_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -103,7 +103,7 @@ void StringFeaturizer_int8_t_Test(
 
         
         // Destroy the contents
-        REQUIRE(StringFeaturizer_int8_t_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_int8_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
@@ -112,14 +112,14 @@ void StringFeaturizer_int8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(StringFeaturizer_int8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <int16_t> */
+/* |  StringFeaturizer <int16> */
 template <typename VectorInputT>
-void StringFeaturizer_int16_t_Test(
+void StringFeaturizer_int16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<std::string> const &)> const &verify_func
@@ -127,9 +127,9 @@ void StringFeaturizer_int16_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    StringFeaturizer_int16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    StringFeaturizer_int16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_int16_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int16_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -140,7 +140,7 @@ void StringFeaturizer_int16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(StringFeaturizer_int16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(StringFeaturizer_int16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -149,7 +149,7 @@ void StringFeaturizer_int16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(StringFeaturizer_int16_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(StringFeaturizer_int16_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -159,7 +159,7 @@ void StringFeaturizer_int16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(StringFeaturizer_int16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(StringFeaturizer_int16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -167,7 +167,7 @@ void StringFeaturizer_int16_t_Test(
         }
     }
 
-    StringFeaturizer_int16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    StringFeaturizer_int16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -175,20 +175,20 @@ void StringFeaturizer_int16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(StringFeaturizer_int16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(StringFeaturizer_int16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    StringFeaturizer_int16_t_TransformerHandle * pTransformerHandle(nullptr);
+    StringFeaturizer_int16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_int16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(StringFeaturizer_int16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -201,7 +201,7 @@ void StringFeaturizer_int16_t_Test(
         std::size_t result_items(0);
 
 
-        REQUIRE(StringFeaturizer_int16_t_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_int16_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -212,7 +212,7 @@ void StringFeaturizer_int16_t_Test(
 
         
         // Destroy the contents
-        REQUIRE(StringFeaturizer_int16_t_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_int16_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
@@ -221,14 +221,14 @@ void StringFeaturizer_int16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(StringFeaturizer_int16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <int32_t> */
+/* |  StringFeaturizer <int32> */
 template <typename VectorInputT>
-void StringFeaturizer_int32_t_Test(
+void StringFeaturizer_int32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<std::string> const &)> const &verify_func
@@ -236,9 +236,9 @@ void StringFeaturizer_int32_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    StringFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    StringFeaturizer_int32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_int32_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int32_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -249,7 +249,7 @@ void StringFeaturizer_int32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(StringFeaturizer_int32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(StringFeaturizer_int32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -258,7 +258,7 @@ void StringFeaturizer_int32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(StringFeaturizer_int32_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(StringFeaturizer_int32_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -268,7 +268,7 @@ void StringFeaturizer_int32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(StringFeaturizer_int32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(StringFeaturizer_int32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -276,7 +276,7 @@ void StringFeaturizer_int32_t_Test(
         }
     }
 
-    StringFeaturizer_int32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    StringFeaturizer_int32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -284,20 +284,20 @@ void StringFeaturizer_int32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(StringFeaturizer_int32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(StringFeaturizer_int32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    StringFeaturizer_int32_t_TransformerHandle * pTransformerHandle(nullptr);
+    StringFeaturizer_int32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_int32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(StringFeaturizer_int32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -310,7 +310,7 @@ void StringFeaturizer_int32_t_Test(
         std::size_t result_items(0);
 
 
-        REQUIRE(StringFeaturizer_int32_t_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_int32_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -321,7 +321,7 @@ void StringFeaturizer_int32_t_Test(
 
         
         // Destroy the contents
-        REQUIRE(StringFeaturizer_int32_t_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_int32_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
@@ -330,14 +330,14 @@ void StringFeaturizer_int32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(StringFeaturizer_int32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <int64_t> */
+/* |  StringFeaturizer <int64> */
 template <typename VectorInputT>
-void StringFeaturizer_int64_t_Test(
+void StringFeaturizer_int64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<std::string> const &)> const &verify_func
@@ -345,9 +345,9 @@ void StringFeaturizer_int64_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    StringFeaturizer_int64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    StringFeaturizer_int64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_int64_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int64_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -358,7 +358,7 @@ void StringFeaturizer_int64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(StringFeaturizer_int64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(StringFeaturizer_int64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -367,7 +367,7 @@ void StringFeaturizer_int64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(StringFeaturizer_int64_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(StringFeaturizer_int64_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -377,7 +377,7 @@ void StringFeaturizer_int64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(StringFeaturizer_int64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(StringFeaturizer_int64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -385,7 +385,7 @@ void StringFeaturizer_int64_t_Test(
         }
     }
 
-    StringFeaturizer_int64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    StringFeaturizer_int64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -393,20 +393,20 @@ void StringFeaturizer_int64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(StringFeaturizer_int64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(StringFeaturizer_int64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    StringFeaturizer_int64_t_TransformerHandle * pTransformerHandle(nullptr);
+    StringFeaturizer_int64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_int64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(StringFeaturizer_int64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -419,7 +419,7 @@ void StringFeaturizer_int64_t_Test(
         std::size_t result_items(0);
 
 
-        REQUIRE(StringFeaturizer_int64_t_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_int64_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -430,7 +430,7 @@ void StringFeaturizer_int64_t_Test(
 
         
         // Destroy the contents
-        REQUIRE(StringFeaturizer_int64_t_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_int64_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
@@ -439,14 +439,14 @@ void StringFeaturizer_int64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(StringFeaturizer_int64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_int64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <uint8_t> */
+/* |  StringFeaturizer <uint8> */
 template <typename VectorInputT>
-void StringFeaturizer_uint8_t_Test(
+void StringFeaturizer_uint8_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<std::string> const &)> const &verify_func
@@ -454,9 +454,9 @@ void StringFeaturizer_uint8_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    StringFeaturizer_uint8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    StringFeaturizer_uint8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_uint8_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint8_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -467,7 +467,7 @@ void StringFeaturizer_uint8_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(StringFeaturizer_uint8_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(StringFeaturizer_uint8_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -476,7 +476,7 @@ void StringFeaturizer_uint8_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(StringFeaturizer_uint8_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(StringFeaturizer_uint8_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -486,7 +486,7 @@ void StringFeaturizer_uint8_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(StringFeaturizer_uint8_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(StringFeaturizer_uint8_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -494,7 +494,7 @@ void StringFeaturizer_uint8_t_Test(
         }
     }
 
-    StringFeaturizer_uint8_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    StringFeaturizer_uint8_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -502,20 +502,20 @@ void StringFeaturizer_uint8_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(StringFeaturizer_uint8_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(StringFeaturizer_uint8_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    StringFeaturizer_uint8_t_TransformerHandle * pTransformerHandle(nullptr);
+    StringFeaturizer_uint8_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_uint8_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint8_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(StringFeaturizer_uint8_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint8_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -528,7 +528,7 @@ void StringFeaturizer_uint8_t_Test(
         std::size_t result_items(0);
 
 
-        REQUIRE(StringFeaturizer_uint8_t_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_uint8_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -539,7 +539,7 @@ void StringFeaturizer_uint8_t_Test(
 
         
         // Destroy the contents
-        REQUIRE(StringFeaturizer_uint8_t_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_uint8_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
@@ -548,14 +548,14 @@ void StringFeaturizer_uint8_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(StringFeaturizer_uint8_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint8_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <uint16_t> */
+/* |  StringFeaturizer <uint16> */
 template <typename VectorInputT>
-void StringFeaturizer_uint16_t_Test(
+void StringFeaturizer_uint16_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<std::string> const &)> const &verify_func
@@ -563,9 +563,9 @@ void StringFeaturizer_uint16_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    StringFeaturizer_uint16_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    StringFeaturizer_uint16_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_uint16_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint16_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -576,7 +576,7 @@ void StringFeaturizer_uint16_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(StringFeaturizer_uint16_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(StringFeaturizer_uint16_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -585,7 +585,7 @@ void StringFeaturizer_uint16_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(StringFeaturizer_uint16_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(StringFeaturizer_uint16_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -595,7 +595,7 @@ void StringFeaturizer_uint16_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(StringFeaturizer_uint16_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(StringFeaturizer_uint16_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -603,7 +603,7 @@ void StringFeaturizer_uint16_t_Test(
         }
     }
 
-    StringFeaturizer_uint16_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    StringFeaturizer_uint16_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -611,20 +611,20 @@ void StringFeaturizer_uint16_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(StringFeaturizer_uint16_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(StringFeaturizer_uint16_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    StringFeaturizer_uint16_t_TransformerHandle * pTransformerHandle(nullptr);
+    StringFeaturizer_uint16_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_uint16_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint16_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(StringFeaturizer_uint16_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint16_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -637,7 +637,7 @@ void StringFeaturizer_uint16_t_Test(
         std::size_t result_items(0);
 
 
-        REQUIRE(StringFeaturizer_uint16_t_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_uint16_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -648,7 +648,7 @@ void StringFeaturizer_uint16_t_Test(
 
         
         // Destroy the contents
-        REQUIRE(StringFeaturizer_uint16_t_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_uint16_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
@@ -657,14 +657,14 @@ void StringFeaturizer_uint16_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(StringFeaturizer_uint16_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint16_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <uint32_t> */
+/* |  StringFeaturizer <uint32> */
 template <typename VectorInputT>
-void StringFeaturizer_uint32_t_Test(
+void StringFeaturizer_uint32_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<std::string> const &)> const &verify_func
@@ -672,9 +672,9 @@ void StringFeaturizer_uint32_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    StringFeaturizer_uint32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    StringFeaturizer_uint32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_uint32_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint32_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -685,7 +685,7 @@ void StringFeaturizer_uint32_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(StringFeaturizer_uint32_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(StringFeaturizer_uint32_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -694,7 +694,7 @@ void StringFeaturizer_uint32_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(StringFeaturizer_uint32_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(StringFeaturizer_uint32_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -704,7 +704,7 @@ void StringFeaturizer_uint32_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(StringFeaturizer_uint32_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(StringFeaturizer_uint32_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -712,7 +712,7 @@ void StringFeaturizer_uint32_t_Test(
         }
     }
 
-    StringFeaturizer_uint32_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    StringFeaturizer_uint32_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -720,20 +720,20 @@ void StringFeaturizer_uint32_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(StringFeaturizer_uint32_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(StringFeaturizer_uint32_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    StringFeaturizer_uint32_t_TransformerHandle * pTransformerHandle(nullptr);
+    StringFeaturizer_uint32_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_uint32_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint32_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(StringFeaturizer_uint32_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint32_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -746,7 +746,7 @@ void StringFeaturizer_uint32_t_Test(
         std::size_t result_items(0);
 
 
-        REQUIRE(StringFeaturizer_uint32_t_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_uint32_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -757,7 +757,7 @@ void StringFeaturizer_uint32_t_Test(
 
         
         // Destroy the contents
-        REQUIRE(StringFeaturizer_uint32_t_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_uint32_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
@@ -766,14 +766,14 @@ void StringFeaturizer_uint32_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(StringFeaturizer_uint32_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint32_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <uint64_t> */
+/* |  StringFeaturizer <uint64> */
 template <typename VectorInputT>
-void StringFeaturizer_uint64_t_Test(
+void StringFeaturizer_uint64_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<std::string> const &)> const &verify_func
@@ -781,9 +781,9 @@ void StringFeaturizer_uint64_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    StringFeaturizer_uint64_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    StringFeaturizer_uint64_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_uint64_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint64_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -794,7 +794,7 @@ void StringFeaturizer_uint64_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(StringFeaturizer_uint64_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(StringFeaturizer_uint64_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -803,7 +803,7 @@ void StringFeaturizer_uint64_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(StringFeaturizer_uint64_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(StringFeaturizer_uint64_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -813,7 +813,7 @@ void StringFeaturizer_uint64_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(StringFeaturizer_uint64_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(StringFeaturizer_uint64_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -821,7 +821,7 @@ void StringFeaturizer_uint64_t_Test(
         }
     }
 
-    StringFeaturizer_uint64_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    StringFeaturizer_uint64_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -829,20 +829,20 @@ void StringFeaturizer_uint64_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(StringFeaturizer_uint64_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(StringFeaturizer_uint64_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    StringFeaturizer_uint64_t_TransformerHandle * pTransformerHandle(nullptr);
+    StringFeaturizer_uint64_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_uint64_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint64_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(StringFeaturizer_uint64_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint64_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -855,7 +855,7 @@ void StringFeaturizer_uint64_t_Test(
         std::size_t result_items(0);
 
 
-        REQUIRE(StringFeaturizer_uint64_t_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_uint64_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -866,7 +866,7 @@ void StringFeaturizer_uint64_t_Test(
 
         
         // Destroy the contents
-        REQUIRE(StringFeaturizer_uint64_t_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_uint64_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
@@ -875,14 +875,14 @@ void StringFeaturizer_uint64_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(StringFeaturizer_uint64_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_uint64_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <float_t> */
+/* |  StringFeaturizer <float> */
 template <typename VectorInputT>
-void StringFeaturizer_float_t_Test(
+void StringFeaturizer_float_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<std::string> const &)> const &verify_func
@@ -890,9 +890,9 @@ void StringFeaturizer_float_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    StringFeaturizer_float_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    StringFeaturizer_float_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_float_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_float_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -903,7 +903,7 @@ void StringFeaturizer_float_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(StringFeaturizer_float_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(StringFeaturizer_float_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -912,7 +912,7 @@ void StringFeaturizer_float_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(StringFeaturizer_float_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(StringFeaturizer_float_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -922,7 +922,7 @@ void StringFeaturizer_float_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(StringFeaturizer_float_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(StringFeaturizer_float_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -930,7 +930,7 @@ void StringFeaturizer_float_t_Test(
         }
     }
 
-    StringFeaturizer_float_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    StringFeaturizer_float_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -938,20 +938,20 @@ void StringFeaturizer_float_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(StringFeaturizer_float_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(StringFeaturizer_float_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    StringFeaturizer_float_t_TransformerHandle * pTransformerHandle(nullptr);
+    StringFeaturizer_float_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_float_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_float_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(StringFeaturizer_float_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_float_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -964,7 +964,7 @@ void StringFeaturizer_float_t_Test(
         std::size_t result_items(0);
 
 
-        REQUIRE(StringFeaturizer_float_t_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_float_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -975,7 +975,7 @@ void StringFeaturizer_float_t_Test(
 
         
         // Destroy the contents
-        REQUIRE(StringFeaturizer_float_t_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_float_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
@@ -984,14 +984,14 @@ void StringFeaturizer_float_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(StringFeaturizer_float_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_float_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 
 /* ---------------------------------------------------------------------- */
-/* |  StringFeaturizer <double_t> */
+/* |  StringFeaturizer <double> */
 template <typename VectorInputT>
-void StringFeaturizer_double_t_Test(
+void StringFeaturizer_double_Test(
     std::vector<VectorInputT> const &training_input,
     std::vector<VectorInputT> const &inference_input,
     std::function<bool (std::vector<std::string> const &)> const &verify_func
@@ -999,9 +999,9 @@ void StringFeaturizer_double_t_Test(
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    StringFeaturizer_double_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    StringFeaturizer_double_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_double_t_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_double_CreateEstimator(&pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
@@ -1012,7 +1012,7 @@ void StringFeaturizer_double_t_Test(
         while(true) {
             TrainingState trainingState(0);
 
-            REQUIRE(StringFeaturizer_double_t_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
+            REQUIRE(StringFeaturizer_double_GetState(pEstimatorHandle, &trainingState, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(trainingState != Training)
@@ -1021,7 +1021,7 @@ void StringFeaturizer_double_t_Test(
             FitResult result(0);
             auto const & input(*iter);
 
-            REQUIRE(StringFeaturizer_double_t_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
+            REQUIRE(StringFeaturizer_double_Fit(pEstimatorHandle, input, &result, &pErrorInfo));
             REQUIRE(pErrorInfo == nullptr);
 
             if(result == ResetAndContinue) {
@@ -1031,7 +1031,7 @@ void StringFeaturizer_double_t_Test(
 
             ++iter;
             if(iter == training_input.end()) {
-                REQUIRE(StringFeaturizer_double_t_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
+                REQUIRE(StringFeaturizer_double_OnDataCompleted(pEstimatorHandle, &pErrorInfo));
                 REQUIRE(pErrorInfo == nullptr);
 
                 iter = training_input.begin();
@@ -1039,7 +1039,7 @@ void StringFeaturizer_double_t_Test(
         }
     }
 
-    StringFeaturizer_double_t_CompleteTraining(pEstimatorHandle, &pErrorInfo);
+    StringFeaturizer_double_CompleteTraining(pEstimatorHandle, &pErrorInfo);
     REQUIRE(pErrorInfo == nullptr);
 
 
@@ -1047,20 +1047,20 @@ void StringFeaturizer_double_t_Test(
     {
         bool is_complete(false);
 
-        REQUIRE(StringFeaturizer_double_t_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
+        REQUIRE(StringFeaturizer_double_IsTrainingComplete(pEstimatorHandle, &is_complete, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
         REQUIRE(is_complete);
     }
 
     // Create the Transformer
-    StringFeaturizer_double_t_TransformerHandle * pTransformerHandle(nullptr);
+    StringFeaturizer_double_TransformerHandle * pTransformerHandle(nullptr);
 
-    REQUIRE(StringFeaturizer_double_t_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_double_CreateTransformerFromEstimator(pEstimatorHandle, &pTransformerHandle, &pErrorInfo));
     REQUIRE(pTransformerHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the estimator
-    REQUIRE(StringFeaturizer_double_t_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_double_DestroyEstimator(pEstimatorHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Inference
@@ -1073,7 +1073,7 @@ void StringFeaturizer_double_t_Test(
         std::size_t result_items(0);
 
 
-        REQUIRE(StringFeaturizer_double_t_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_double_Transform(pTransformerHandle, input, &result_ptr, &result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
 
         #if (defined __apple_build_version__)
@@ -1084,7 +1084,7 @@ void StringFeaturizer_double_t_Test(
 
         
         // Destroy the contents
-        REQUIRE(StringFeaturizer_double_t_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
+        REQUIRE(StringFeaturizer_double_DestroyTransformedData(result_ptr, result_items, &pErrorInfo));
         REQUIRE(pErrorInfo == nullptr);
     }
 
@@ -1093,7 +1093,7 @@ void StringFeaturizer_double_t_Test(
     // No trailing destroy statement
 
     // Destroy the transformer
-    REQUIRE(StringFeaturizer_double_t_DestroyTransformer(pTransformerHandle, &pErrorInfo));
+    REQUIRE(StringFeaturizer_double_DestroyTransformer(pTransformerHandle, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 }
 

--- a/src/SharedLibrary/IntegrationTests/SharedLibrary_CatImputerFeaturizer_IntegrationTest.cpp
+++ b/src/SharedLibrary/IntegrationTests/SharedLibrary_CatImputerFeaturizer_IntegrationTest.cpp
@@ -9,7 +9,7 @@
 #include "../../3rdParty/optional.h"
 
 TEST_CASE("int8") {
-    CatImputerFeaturizer_int8_t_Test(
+    CatImputerFeaturizer_int8_Test(
         std::vector<nonstd::optional<std::int8_t>>{
             static_cast<std::int8_t>(1),
             static_cast<std::int8_t>(2),
@@ -55,4 +55,3 @@ TEST_CASE("string") {
         }
     );
 }
-

--- a/src/SharedLibrary/IntegrationTests/SharedLibrary_HOHVFeaturizer_IntegrationTest.cpp
+++ b/src/SharedLibrary/IntegrationTests/SharedLibrary_HOHVFeaturizer_IntegrationTest.cpp
@@ -8,7 +8,7 @@
 #include "GeneratedCode/SharedLibraryTests_HashOneHotVectorizerFeaturizer.h"
 
 TEST_CASE("int8") {
-    HashOneHotVectorizerFeaturizer_int8_t_Test(
+    HashOneHotVectorizerFeaturizer_int8_Test(
         std::vector<std::int8_t>(),
         std::vector<std::int8_t>{
             static_cast<std::int8_t>(15)

--- a/src/SharedLibrary/IntegrationTests/SharedLibrary_IMFeaturizer_IntegrationTest.cpp
+++ b/src/SharedLibrary/IntegrationTests/SharedLibrary_IMFeaturizer_IntegrationTest.cpp
@@ -8,7 +8,7 @@
 #include "GeneratedCode/SharedLibraryTests_ImputationMarkerFeaturizer.h"
 
 TEST_CASE("int8") {
-    ImputationMarkerFeaturizer_int8_t_Test(
+    ImputationMarkerFeaturizer_int8_Test(
         std::vector<nonstd::optional<std::int8_t>>(),
         std::vector<nonstd::optional<std::int8_t>>{
             static_cast<std::int8_t>(1),
@@ -23,12 +23,12 @@ TEST_CASE("int8") {
 
 TEST_CASE("double") {
     std::double_t input_d = std::numeric_limits<std::double_t>::quiet_NaN();
-    ImputationMarkerFeaturizer_double_t_Test(
+    ImputationMarkerFeaturizer_double_Test(
         std::vector<std::double_t>(),
         std::vector<std::double_t>{
             static_cast<std::double_t>(1.0),
-            static_cast<std::double_t>(2.0),   
-            input_d    
+            static_cast<std::double_t>(2.0),
+            input_d
         },
         [](std::vector<bool> const &args) {
             return args == std::vector<bool>{false, false, true};

--- a/src/SharedLibrary/IntegrationTests/SharedLibrary_LEFeaturizer_IntegrationTest.cpp
+++ b/src/SharedLibrary/IntegrationTests/SharedLibrary_LEFeaturizer_IntegrationTest.cpp
@@ -9,7 +9,7 @@
 
 
 TEST_CASE("int8") {
-    LabelEncoderFeaturizer_int8_t_Test(
+    LabelEncoderFeaturizer_int8_Test(
         std::vector<std::int8_t>{
             static_cast<std::int8_t>(10),
             static_cast<std::int8_t>(20),

--- a/src/SharedLibrary/IntegrationTests/SharedLibrary_MASFeaturizer_IntegrationTest.cpp
+++ b/src/SharedLibrary/IntegrationTests/SharedLibrary_MASFeaturizer_IntegrationTest.cpp
@@ -22,7 +22,7 @@ bool FuzzyCheck(std::vector<T> const & vec1, std::vector<T> const & vec2, std::d
 }
 
 TEST_CASE("standard-int8_t-float_t") {
-    MaxAbsScalarFeaturizer_int8_t_Test(
+    MaxAbsScalarFeaturizer_int8_Test(
         std::vector<std::int8_t>{
             static_cast<std::int8_t>(1),
             static_cast<std::int8_t>(3),
@@ -38,10 +38,10 @@ TEST_CASE("standard-int8_t-float_t") {
             static_cast<std::int8_t>(-4)
         },
         [](std::vector<std::float_t> const &args) {
-            return FuzzyCheck(args, std::vector<std::float_t>{static_cast<std::float_t>( 0.1), 
-                                                              static_cast<std::float_t>( 0.3), 
-                                                              static_cast<std::float_t>( 1.0), 
-                                                              static_cast<std::float_t>(-0.2), 
+            return FuzzyCheck(args, std::vector<std::float_t>{static_cast<std::float_t>( 0.1),
+                                                              static_cast<std::float_t>( 0.3),
+                                                              static_cast<std::float_t>( 1.0),
+                                                              static_cast<std::float_t>(-0.2),
                                                               static_cast<std::float_t>(-0.4)});
         }
     );

--- a/src/SharedLibrary/IntegrationTests/SharedLibrary_MDFeaturizer_IntegrationTest.cpp
+++ b/src/SharedLibrary/IntegrationTests/SharedLibrary_MDFeaturizer_IntegrationTest.cpp
@@ -8,7 +8,7 @@
 #include "GeneratedCode/SharedLibraryTests_MissingDummiesFeaturizer.h"
 
 TEST_CASE("int8") {
-    MissingDummiesFeaturizer_int8_t_Test(
+    MissingDummiesFeaturizer_int8_Test(
         std::vector<nonstd::optional<std::int8_t>>(),
         std::vector<nonstd::optional<std::int8_t>>{
             static_cast<std::int8_t>(1),
@@ -23,12 +23,12 @@ TEST_CASE("int8") {
 
 TEST_CASE("double") {
     std::double_t input_d = std::numeric_limits<std::double_t>::quiet_NaN();
-    MissingDummiesFeaturizer_double_t_Test(
+    MissingDummiesFeaturizer_double_Test(
         std::vector<std::double_t>(),
         std::vector<std::double_t>{
             static_cast<std::double_t>(1.0),
-            static_cast<std::double_t>(2.0),   
-            input_d    
+            static_cast<std::double_t>(2.0),
+            input_d
         },
         [](std::vector<std::int8_t> const &args) {
             return args == std::vector<std::int8_t>{0, 0, 1};

--- a/src/SharedLibrary/IntegrationTests/SharedLibrary_MMSFeaturizer_IntegrationTest.cpp
+++ b/src/SharedLibrary/IntegrationTests/SharedLibrary_MMSFeaturizer_IntegrationTest.cpp
@@ -8,7 +8,7 @@
 #include "GeneratedCode/SharedLibraryTests_MinMaxScalarFeaturizer.h"
 
 TEST_CASE("double_t") {
-    MinMaxScalarFeaturizer_double_t_Test(
+    MinMaxScalarFeaturizer_double_Test(
         std::vector<std::double_t>{
             static_cast<std::double_t>(-1),
             static_cast<std::double_t>(-0.5),

--- a/src/SharedLibrary/IntegrationTests/SharedLibrary_OHEFeaturizer_IntegrationTest.cpp
+++ b/src/SharedLibrary/IntegrationTests/SharedLibrary_OHEFeaturizer_IntegrationTest.cpp
@@ -9,7 +9,7 @@
 
 
 TEST_CASE("int8") {
-    OneHotEncoderFeaturizer_int8_t_Test(
+    OneHotEncoderFeaturizer_int8_Test(
         std::vector<std::int8_t>{
             static_cast<std::int8_t>(10),
             static_cast<std::int8_t>(20),

--- a/src/SharedLibrary/IntegrationTests/SharedLibrary_RSFeaturizer_IntegrationTest.cpp
+++ b/src/SharedLibrary/IntegrationTests/SharedLibrary_RSFeaturizer_IntegrationTest.cpp
@@ -22,11 +22,11 @@ bool FuzzyCheck(std::vector<T> const & vec1, std::vector<T> const & vec2, std::d
     return true;
 }
 
-TEST_CASE("standard-int8_t-float_t") {
+TEST_CASE("standard-int8-float_t") {
     std::float_t const                      qMin(25.0f);
     std::float_t const                      qMax(75.0f);
 
-    RobustScalarFeaturizer_int8_t_Test(
+    RobustScalarFeaturizer_int8_Test(
         std::vector<std::int8_t>{
             static_cast<std::int8_t>(1),
             static_cast<std::int8_t>(3),
@@ -50,11 +50,11 @@ TEST_CASE("standard-int8_t-float_t") {
     );
 }
 
-TEST_CASE("standard-int32_t-double_t") {
+TEST_CASE("standard-int32-double") {
     std::float_t const                      qMin(25.0f);
     std::float_t const                      qMax(75.0f);
 
-    RobustScalarFeaturizer_int32_t_Test(
+    RobustScalarFeaturizer_int32_Test(
         std::vector<std::int32_t>{
             static_cast<std::int32_t>(1),
             static_cast<std::int32_t>(3),
@@ -78,24 +78,24 @@ TEST_CASE("standard-int32_t-double_t") {
     );
 }
 
-TEST_CASE("CreateEstimatorWithDefault-int8_t") {
+TEST_CASE("CreateEstimatorWithDefault-int8") {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    RobustScalarFeaturizer_int8_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    RobustScalarFeaturizer_int8_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_int8_t_CreateEstimatorWithDefault(true, &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int8_CreateEstimatorWithDefault(true, &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 }
 
-TEST_CASE("CreateEstimatorWithDefault-int32_t") {
+TEST_CASE("CreateEstimatorWithDefault-int32") {
     ErrorInfoHandle * pErrorInfo(nullptr);
 
     // Create the estimator
-    RobustScalarFeaturizer_int32_t_EstimatorHandle *pEstimatorHandle(nullptr);
+    RobustScalarFeaturizer_int32_EstimatorHandle *pEstimatorHandle(nullptr);
 
-    REQUIRE(RobustScalarFeaturizer_int32_t_CreateEstimatorWithDefault(true, &pEstimatorHandle, &pErrorInfo));
+    REQUIRE(RobustScalarFeaturizer_int32_CreateEstimatorWithDefault(true, &pEstimatorHandle, &pErrorInfo));
     REQUIRE(pEstimatorHandle != nullptr);
     REQUIRE(pErrorInfo == nullptr);
 }

--- a/src/SharedLibrary/IntegrationTests/SharedLibrary_StringFeaturizer_IntegrationTest.cpp
+++ b/src/SharedLibrary/IntegrationTests/SharedLibrary_StringFeaturizer_IntegrationTest.cpp
@@ -8,7 +8,7 @@
 #include "GeneratedCode/SharedLibraryTests_StringFeaturizer.h"
 
 TEST_CASE("int8") {
-    StringFeaturizer_int8_t_Test(
+    StringFeaturizer_int8_Test(
         std::vector<std::int8_t>(),
         {1, 2, -3, 4},
         [](std::vector<std::string> const &args) {
@@ -18,7 +18,7 @@ TEST_CASE("int8") {
 }
 
 TEST_CASE("int16") {
-    StringFeaturizer_int16_t_Test(
+    StringFeaturizer_int16_Test(
         std::vector<std::int16_t>(),
         {1000, 2000, -3000, 4000},
         [](std::vector<std::string> const &args) {
@@ -28,7 +28,7 @@ TEST_CASE("int16") {
 }
 
 TEST_CASE("int32") {
-    StringFeaturizer_int32_t_Test(
+    StringFeaturizer_int32_Test(
         std::vector<std::int32_t>(),
         {1000, 2000, -3000, 4000},
         [](std::vector<std::string> const &args) {
@@ -38,7 +38,7 @@ TEST_CASE("int32") {
 }
 
 TEST_CASE("int64") {
-    StringFeaturizer_int64_t_Test(
+    StringFeaturizer_int64_Test(
         std::vector<std::int64_t>(),
         {1000, 2000, -3000, 4000},
         [](std::vector<std::string> const &args) {
@@ -48,7 +48,7 @@ TEST_CASE("int64") {
 }
 
 TEST_CASE("uint8") {
-    StringFeaturizer_uint8_t_Test(
+    StringFeaturizer_uint8_Test(
         std::vector<std::uint8_t>(),
         {1, 2, 3, 4},
         [](std::vector<std::string> const &args) {
@@ -58,7 +58,7 @@ TEST_CASE("uint8") {
 }
 
 TEST_CASE("uint16") {
-    StringFeaturizer_uint16_t_Test(
+    StringFeaturizer_uint16_Test(
         std::vector<std::uint16_t>(),
         {1000, 2000, 3000, 4000},
         [](std::vector<std::string> const &args) {
@@ -68,7 +68,7 @@ TEST_CASE("uint16") {
 }
 
 TEST_CASE("uint32") {
-    StringFeaturizer_uint32_t_Test(
+    StringFeaturizer_uint32_Test(
         std::vector<std::uint32_t>(),
         {1000, 2000, 3000, 4000},
         [](std::vector<std::string> const &args) {
@@ -78,7 +78,7 @@ TEST_CASE("uint32") {
 }
 
 TEST_CASE("uint64") {
-    StringFeaturizer_uint64_t_Test(
+    StringFeaturizer_uint64_Test(
         std::vector<std::uint64_t>(),
         {1000, 2000, 3000, 4000},
         [](std::vector<std::string> const &args) {
@@ -88,7 +88,7 @@ TEST_CASE("uint64") {
 }
 
 TEST_CASE("float") {
-    StringFeaturizer_float_t_Test(
+    StringFeaturizer_float_Test(
         std::vector<std::float_t>(),
         {1.1f, 2.22f, -3.333f, 4.4444f},
         [](std::vector<std::string> const &args) {
@@ -98,7 +98,7 @@ TEST_CASE("float") {
 }
 
 TEST_CASE("double") {
-    StringFeaturizer_double_t_Test(
+    StringFeaturizer_double_Test(
         std::vector<std::double_t>(),
         {1.1, 2.22, -3.333, 4.4444},
         [](std::vector<std::string> const &args) {

--- a/src/SharedLibrary/SharedLibrary_RobustScalarFeaturizerCustom.cpp
+++ b/src/SharedLibrary/SharedLibrary_RobustScalarFeaturizerCustom.cpp
@@ -49,43 +49,43 @@ bool RobustScalarFeaturizer_CreateEstimatorWithDefault( /*in*/ bool withCenterin
 
 extern "C" {
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     return RobustScalarFeaturizer_CreateEstimatorWithDefault<std::int8_t, std::float_t>(withCentering, ppHandle, ppErrorInfo);
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     return RobustScalarFeaturizer_CreateEstimatorWithDefault<std::int16_t, std::float_t>(withCentering, ppHandle, ppErrorInfo);
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     return RobustScalarFeaturizer_CreateEstimatorWithDefault<std::uint8_t, std::float_t>(withCentering, ppHandle, ppErrorInfo);
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     return RobustScalarFeaturizer_CreateEstimatorWithDefault<std::uint16_t, std::float_t>(withCentering, ppHandle, ppErrorInfo);
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     return RobustScalarFeaturizer_CreateEstimatorWithDefault<std::int32_t, std::double_t>(withCentering, ppHandle, ppErrorInfo);
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     return RobustScalarFeaturizer_CreateEstimatorWithDefault<std::uint32_t, std::double_t>(withCentering, ppHandle, ppErrorInfo);
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     return RobustScalarFeaturizer_CreateEstimatorWithDefault<std::int64_t, std::double_t>(withCentering, ppHandle, ppErrorInfo);
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     return RobustScalarFeaturizer_CreateEstimatorWithDefault<std::uint64_t, std::double_t>(withCentering, ppHandle, ppErrorInfo);
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     return RobustScalarFeaturizer_CreateEstimatorWithDefault<std::float_t, std::float_t>(withCentering, ppHandle, ppErrorInfo);
 }
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_CreateEstimatorWithDefault( /*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     return RobustScalarFeaturizer_CreateEstimatorWithDefault<std::double_t, std::double_t>(withCentering, ppHandle, ppErrorInfo);
 }
 

--- a/src/SharedLibrary/SharedLibrary_RobustScalarFeaturizerCustom.h
+++ b/src/SharedLibrary/SharedLibrary_RobustScalarFeaturizerCustom.h
@@ -11,16 +11,16 @@ extern "C" {
 
 /* This file exposes non-standard functionality in the RobustScalarFeaturizer */
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_t_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_t_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_t_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint8_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_t_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint16_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_t_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_float_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int8_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int16_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint8_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint8_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint16_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint16_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_float_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_float_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_t_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_t_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_t_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint32_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_t_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint64_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
-FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_t_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_double_t_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int32_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_int64_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_int64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint32_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint32_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_uint64_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_uint64_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool RobustScalarFeaturizer_double_CreateEstimatorWithDefault(/*in*/ bool withCentering, /*out*/ RobustScalarFeaturizer_double_EstimatorHandle **ppHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 } // extern "C"

--- a/src/Tools/CodeGenerator/Featurizers.yaml
+++ b/src/Tools/CodeGenerator/Featurizers.yaml
@@ -19,8 +19,8 @@
     within the host frameworks and programming languages.
 
     C++-style pseudo signature:
-      std::float_t execute(std::float_t const &value);
-      std::double_t execute(std::double_t const &value);
+      float execute(float const &value);
+      double execute(double const &value);
       template <typename T> T execute(std::optional<T> const &value);
 
     Examples (where 55.5 is the mode value):
@@ -31,18 +31,18 @@
   templates:
     - name: T
       types:
-        - std::int8_t
-        - std::int16_t
-        - std::int32_t
-        - std::int64_t
-        - std::uint8_t
-        - std::uint16_t
-        - std::uint32_t
-        - std::uint64_t
-        - std::float_t
-        - std::double_t
+        - int8
+        - int16
+        - int32
+        - int64
+        - uint8
+        - uint16
+        - uint32
+        - uint64
+        - float
+        - double
         - bool
-        - std::string
+        - string
 
   type_mappings:
     - input_type: T
@@ -74,7 +74,7 @@
     Extracts various datetime-related values from a UTC time_point.
 
     C++-style pseudo signature:
-      TimePoint execute(std::chron::system_clock::time_point const &value);
+      TimePoint execute(std::chrono::system_clock::time_point const &value);
 
     Examples:
       Given a time_point 'value' representing "November 17, 1976 12:27:04PM":
@@ -104,62 +104,62 @@
       }
 
   type_mappings:
-    - input_type: std::int64_t
+    - input_type: int64
       output_type: TimePoint
 
   configuration_params:
-    - type: std::string
+    - type: string
       name: optionalCountryName
       is_optional: true
 
-    - type: std::string
+    - type: string
       name: optionalDataRootDir
       is_optional: true
 
   custom_structs:
     - name: TimePoint
       members:
-        - type: std::int32_t
+        - type: int32
           name: year
-        - type: std::uint8_t
+        - type: uint8
           name: month
-        - type: std::uint8_t
+        - type: uint8
           name: day
-        - type: std::uint8_t
+        - type: uint8
           name: hour
-        - type: std::uint8_t
+        - type: uint8
           name: minute
-        - type: std::uint8_t
+        - type: uint8
           name: second
-        - type: std::uint8_t
+        - type: uint8
           name: amPm
-        - type: std::uint8_t
+        - type: uint8
           name: hour12
-        - type: std::uint8_t
+        - type: uint8
           name: dayOfWeek
-        - type: std::uint8_t
+        - type: uint8
           name: dayOfQuarter
-        - type: std::uint16_t
+        - type: uint16
           name: dayOfYear
-        - type: std::uint16_t
+        - type: uint16
           name: weekOfMonth
-        - type: std::uint8_t
+        - type: uint8
           name: quarterOfYear
-        - type: std::uint8_t
+        - type: uint8
           name: halfOfYear
-        - type: std::uint8_t
+        - type: uint8
           name: weekIso
-        - type: std::int32_t
+        - type: int32
           name: yearIso
-        - type: std::string
+        - type: string
           name: monthLabel
-        - type: std::string
+        - type: string
           name: amPmLabel
-        - type: std::string
+        - type: string
           name: dayOfWeekLabel
-        - type: std::string
+        - type: string
           name: holidayName
-        - type: std::uint8_t
+        - type: uint8
           name: isPaidTimeOff
 
 # ----------------------------------------------------------------------
@@ -189,29 +189,29 @@
   templates:
     - name: T
       types:
-        - std::int8_t
-        - std::int16_t
-        - std::int32_t
-        - std::int64_t
-        - std::uint8_t
-        - std::uint16_t
-        - std::uint32_t
-        - std::uint64_t
-        - std::float_t
-        - std::double_t
+        - int8
+        - int16
+        - int32
+        - int64
+        - uint8
+        - uint16
+        - uint32
+        - uint64
+        - float
+        - double
         - bool
-        - std::string
+        - string
 
   type_mappings:
     - input_type: T
       output_type: HashOneHotVectorizerStruct
 
   configuration_params:
-    - type: std::uint32_t
+    - type: uint32
       name: hashingSeedVal
       is_optional: false
 
-    - type: std::uint32_t
+    - type: uint32
       name: numCols
       is_optional: false
 
@@ -223,9 +223,9 @@
         itself.
 
       members:
-        - type: std::uint32_t
+        - type: uint32
           name: ColIndex
-        - type: std::uint32_t
+        - type: uint32
           name: NumCols
         - type: bool
           name: Val
@@ -239,32 +239,32 @@
     Returns true if the input is null, false if it is not.
 
     C++-style pseudo signature:
-      bool execute(std::float_t const &value);
-      bool execute(std::double_t const &value);
+      bool execute(float const &value);
+      bool execute(double const &value);
       template <typename T> bool execute(std::optional<T> const &value);
 
     Examples:
       3.0 -> false
       NaN -> true
       "foo" -> false
-      std::optional<std::string>() -> true
-      std::optional<std::string>("bar") -> false
+      std::optional<string>() -> true
+      std::optional<string>("bar") -> false
 
   templates:
     - name: T
       types:
-        - std::int8_t
-        - std::int16_t
-        - std::int32_t
-        - std::int64_t
-        - std::uint8_t
-        - std::uint16_t
-        - std::uint32_t
-        - std::uint64_t
-        - std::float_t
-        - std::double_t
+        - int8
+        - int16
+        - int32
+        - int64
+        - uint8
+        - uint16
+        - uint32
+        - uint64
+        - float
+        - double
         - bool
-        - std::string
+        - string
 
   type_mappings:
     - input_type: T
@@ -284,9 +284,9 @@
       - mode: Most common value encountered during training (valid for all types)
 
     C++-style pseudo signature:
-      std::float_t execute(std::float_t const &value);                      // Valid for mean, median, mode
-      std::double_t execute(std::double_t const &value);                    // Valid for mean, median, mode
-      std::string execute(std::optional<std::string> const &value);         // Valid for mode
+      float execute(float const &value);                      // Valid for mean, median, mode
+      double execute(double const &value);                    // Valid for mean, median, mode
+      string execute(std::optional<string> const &value);     // Valid for mode
 
     Examples:
       Mean, with training data [1, 2, 3, 4]: mean of 2.5
@@ -302,7 +302,7 @@
       Mode, with training data ["one", "two", "three", "two"]: mode of "two"
 
         execute("foo") -> "foo"
-        execute(std::optional<std::string>()) -> "two"
+        execute(std::optional<string>()) -> "two"
 
   status: Pending
 
@@ -314,7 +314,7 @@
     Returns a unique id for the input based on all values encountered during training.
 
     C++-style pseudo signature:
-      template <typename T> std::uint32_t execute(T const &value);
+      template <typename T> uint32 execute(T const &value);
 
     Examples:
       Assuming the training data of ["A", "B", "C"]...
@@ -327,22 +327,22 @@
   templates:
     - name: T
       types:
-        - std::int8_t
-        - std::int16_t
-        - std::int32_t
-        - std::int64_t
-        - std::uint8_t
-        - std::uint16_t
-        - std::uint32_t
-        - std::uint64_t
-        - std::float_t
-        - std::double_t
+        - int8
+        - int16
+        - int32
+        - int64
+        - uint8
+        - uint16
+        - uint32
+        - uint64
+        - float
+        - double
         - bool
-        - std::string
+        - string
 
   type_mappings:
     - input_type: T
-      output_type: std::uint32_t
+      output_type: uint32
 
   configuration_params:
     - type: bool
@@ -358,8 +358,8 @@
     Scales input based on the maximum absolute value of all data encountered during training.
 
     C++-style pseudo signature:
-      std::float_t execute(std::uint16_t value);
-      std::double_t execute(std::uint32_t value);
+      float execute(uint16 value);
+      double execute(uint32 value);
 
     Examples:
       Given a training set of [1.0, -2.0, 3.0, -4.0], where 4.0 is the absolute value of the
@@ -372,26 +372,26 @@
   templates:
     - name: TInputFloat
       types:
-        - std::int8_t
-        - std::int16_t
-        - std::uint8_t
-        - std::uint16_t
-        - std::float_t
+        - int8
+        - int16
+        - uint8
+        - uint16
+        - float
 
     - name: TInputDouble
       types:
-        - std::int32_t
-        - std::int64_t
-        - std::uint32_t
-        - std::uint64_t
-        - std::double_t
+        - int32
+        - int64
+        - uint32
+        - uint64
+        - double
 
   type_mappings:
     - input_type: TInputFloat
-      output_type: std::float_t
+      output_type: float
 
     - input_type: TInputDouble
-      output_type: std::double_t
+      output_type: double
 
 # ----------------------------------------------------------------------
 - name: MinMaxScalarFeaturizer
@@ -402,7 +402,7 @@
     during training.
 
     C++-style pseudo signature:
-        template <typeanem T> std::double_t(T const &value);
+        template <typeanem T> double(T const &value);
 
     Examples:
       Given the training data [1, 2, 3, 4, 5];
@@ -416,20 +416,20 @@
   templates:
     - name: T
       types:
-        - std::int8_t
-        - std::int16_t
-        - std::int32_t
-        - std::int64_t
-        - std::uint8_t
-        - std::uint16_t
-        - std::uint32_t
-        - std::uint64_t
-        - std::float_t
-        - std::double_t
+        - int8
+        - int16
+        - int32
+        - int64
+        - uint8
+        - uint16
+        - uint32
+        - uint64
+        - float
+        - double
 
   type_mappings:
     - input_type: T
-      output_type: std::double_t
+      output_type: double
 
 # ----------------------------------------------------------------------
 - name: MissingDummiesFeaturizer
@@ -440,37 +440,37 @@
     Returns 1 if the input is null, 0 if it is not.
 
     C++-style pseudo signature:
-        std::int8_t execute(std::float_t const &value);
-        std::int8_t execute(std::double_t const &value);
-        template <typename T> std::int8_t execute(T const &value);
+        int8 execute(float const &value);
+        int8 execute(double const &value);
+        template <typename T> int8 execute(T const &value);
 
     Examples:
       1.0 -> 0
       NaN -> 1
       "foo" -> 0
-      std::optional<std::string>() -> 1
-      std::optional<std::string>("bar") -> 0
+      std::optional<string>() -> 1
+      std::optional<string>("bar") -> 0
 
   templates:
     - name: T
       types:
-        - std::int8_t
-        - std::int16_t
-        - std::int32_t
-        - std::int64_t
-        - std::uint8_t
-        - std::uint16_t
-        - std::uint32_t
-        - std::uint64_t
-        - std::float_t
-        - std::double_t
+        - int8
+        - int16
+        - int32
+        - int64
+        - uint8
+        - uint16
+        - uint32
+        - uint64
+        - float
+        - double
         - bool
-        - std::string
+        - string
 
   type_mappings:
     - input_type: T
       is_input_optional: true
-      output_type: std::int8_t
+      output_type: int8
 
 # ----------------------------------------------------------------------
 - name: NumericalizeFeaturizer
@@ -480,7 +480,7 @@
     This is the LabelEncoder, but returns a null value for categories not encountered during training.
 
     C++-style pseudo signature:
-      template <typename T> std::float_t execute(T const &value);
+      template <typename T> float execute(T const &value);
 
     Examples:
       execute("encountered") -> <unique id>
@@ -511,18 +511,18 @@
   templates:
     - name: T
       types:
-        - std::int8_t
-        - std::int16_t
-        - std::int32_t
-        - std::int64_t
-        - std::uint8_t
-        - std::uint16_t
-        - std::uint32_t
-        - std::uint64_t
-        - std::float_t
-        - std::double_t
+        - int8
+        - int16
+        - int32
+        - int64
+        - uint8
+        - uint16
+        - uint32
+        - uint64
+        - float
+        - double
         - bool
-        - std::string
+        - string
 
   type_mappings:
     - input_type: T
@@ -536,11 +536,11 @@
   custom_structs:
     - name: OneHotStruct
       members:
-        - type: std::uint32_t
+        - type: uint32
           name: index
-        - type: std::uint32_t
+        - type: uint32
           name: size
-        - type: std::uint32_t
+        - type: uint32
           name: appearances
 
 # ----------------------------------------------------------------------
@@ -575,37 +575,37 @@
   templates:
     - name: TInputFloat
       types:
-        - std::int8_t
-        - std::int16_t
-        - std::uint8_t
-        - std::uint16_t
-        - std::float_t
+        - int8
+        - int16
+        - uint8
+        - uint16
+        - float
 
     - name: TInputDouble
       types:
-        - std::int32_t
-        - std::int64_t
-        - std::uint32_t
-        - std::uint64_t
-        - std::double_t
+        - int32
+        - int64
+        - uint32
+        - uint64
+        - double
 
   type_mappings:
     - input_type: TInputFloat
-      output_type: std::float_t
+      output_type: float
 
     - input_type: TInputDouble
-      output_type: std::double_t
+      output_type: double
 
   configuration_params:
     - type: bool
       name: withCentering
       is_optional: false
 
-    - type: std::float_t
+    - type: float
       name: qRangeMin
       is_optional: true
 
-    - type: std::float_t
+    - type: float
       name: qRangeMax
       is_optional: true
 
@@ -617,7 +617,7 @@
     Computes the L1 and/or L2 norm for a provided data set.
 
     C++-style pseudo signature:
-      template <typename T> std::tuple<std::float_t, std::float_t> execute(std::vector<T> const &value);
+      template <typename T> std::tuple<float, float> execute(std::vector<T> const &value);
 
     Examples:
       TODO
@@ -648,7 +648,7 @@
     Converts the input into a string representation based on the input's type.
 
     C++-style pseudo signature:
-      template <typename T> std::string execute(T const &value);
+      template <typename T> string execute(T const &value);
 
     Examples:
       execute(1) -> "1"
@@ -657,22 +657,22 @@
   templates:
     - name: T
       types:
-        - std::int8_t
-        - std::int16_t
-        - std::int32_t
-        - std::int64_t
-        - std::uint8_t
-        - std::uint16_t
-        - std::uint32_t
-        - std::uint64_t
-        - std::float_t
-        - std::double_t
+        - int8
+        - int16
+        - int32
+        - int64
+        - uint8
+        - uint16
+        - uint32
+        - uint64
+        - float
+        - double
         - bool
-        - std::string
+        - string
 
   type_mappings:
     - input_type: T
-      output_type: std::string
+      output_type: string
 
 # ----------------------------------------------------------------------
 - name: TfidfVectorizerFeaturizer

--- a/src/Tools/CodeGenerator/Plugin.py
+++ b/src/Tools/CodeGenerator/Plugin.py
@@ -55,6 +55,7 @@ class Plugin(Interface.Interface):
         """Generates content based on the provided data. Returns a result code."""
         raise Exception("Abstract method")
 
+
 # ----------------------------------------------------------------------
 class TypeVisitor(Interface.Interface):
     """Visitor for types supported by the Featurization library"""
@@ -75,33 +76,31 @@ class TypeVisitor(Interface.Interface):
         **kwargs
     ):
         simple_type_map = {
-            "int8_t": cls.OnInt8,
-            "int16_t": cls.OnInt16,
-            "int32_t": cls.OnInt32,
-            "int64_t": cls.OnInt64,
-            "uint8_t": cls.OnUInt8,
-            "uint16_t": cls.OnUInt16,
-            "uint32_t": cls.OnUInt32,
-            "uint64_t": cls.OnUInt64,
-            "float32_t": cls.OnFloat32,
-            "float_t": cls.OnFloat32,
-            "double_t": cls.OnFloat64,
+            "int8": cls.OnInt8,
+            "int16": cls.OnInt16,
+            "int32": cls.OnInt32,
+            "int64": cls.OnInt64,
+            "uint8": cls.OnUInt8,
+            "uint16": cls.OnUInt16,
+            "uint32": cls.OnUInt32,
+            "uint64": cls.OnUInt64,
+            "float32": cls.OnFloat32,
+            "float": cls.OnFloat32,
+            "double": cls.OnFloat64,
             "bool": cls.OnBool,
             "string": cls.OnString,
         }
 
-        search_string = type_string.replace("std::", "")
-
-        func = simple_type_map.get(search_string, None)
+        func = simple_type_map.get(type_string, None)
         if func is not None:
             return func(type_string, *args, **kwargs)
 
         if cls._Accept_Regex is None:
             cls._Accept_Regex = re.compile(r"^(?P<type>\S+)<(?P<template>.+)>$")
 
-        match = cls._Accept_Regex.match(search_string)
+        match = cls._Accept_Regex.match(type_string)
         if not match:
-            if supported_custom_types and search_string in supported_custom_types:
+            if supported_custom_types and type_string in supported_custom_types:
                 return cls.OnCustomType(type_string, *args, **kwargs)
 
             raise Exception("'{}' is not a supported type".format(type_string))
@@ -123,7 +122,12 @@ class TypeVisitor(Interface.Interface):
 
         template_args = cls._GetTemplateArgs(match.group("template"))
         if len(template_args) != expected_num_template_args:
-            raise Exception("'{}' was expected to have {} template arg(s)".format(type_string, expected_num_template_args))
+            raise Exception(
+                "'{}' was expected to have {} template arg(s)".format(
+                    type_string,
+                    expected_num_template_args,
+                ),
+            )
 
         return func(template_args, *args, **kwargs)
 
@@ -270,7 +274,7 @@ class TypeVisitor(Interface.Interface):
                 if bracket_count or brace_count or paren_count or template_count:
                     continue
 
-                template_args.append(template[prev_index : index].strip())
+                template_args.append(template[prev_index:index].strip())
                 prev_index = index + 1
 
         if prev_index < len(template):

--- a/src/Tools/CodeGenerator/Plugins/MLNetPlugin.py
+++ b/src/Tools/CodeGenerator/Plugins/MLNetPlugin.py
@@ -903,8 +903,6 @@ class CSharpData(object):
             # so that we only need to perform this initialization once.
             cls._type_info_factory_classes = type_info_factory_classes
 
-        the_type = the_type.replace("std::", "").replace("_t", "")
-
         for type_info_factory_class in cls._type_info_factory_classes:
             if type_info_factory_class.TypeName == the_type:
                 return type_info_factory_class

--- a/src/Tools/CodeGenerator/Plugins/OnnxRuntimePlugin.py
+++ b/src/Tools/CodeGenerator/Plugins/OnnxRuntimePlugin.py
@@ -71,17 +71,6 @@ class Plugin(PluginBase):
                 output_types = OrderedDict()
 
                 for item in items:
-                    item.input_type = (
-                        item.input_type
-                        if ("float" in item.input_type or "double" in item.input_type)
-                        else item.input_type
-                    )
-                    item.output_type = (
-                        item.output_type
-                        if ("float" in item.output_type or "double" in item.output_type)
-                        else item.output_type
-                    )
-
                     if (
                         item.is_input_optional
                         and item.input_type not in supported_optional_types
@@ -766,8 +755,8 @@ def _GenerateKernel(
     if item.is_input_optional:
         prefix_statements += textwrap.dedent(
             """\
-            inline float const& PreprocessOptional(float const& value) { return value; }
-            inline double const& PreprocessOptional(double const& value) { return value; }
+            inline float_t const& PreprocessOptional(float_t const& value) { return value; }
+            inline double_t const& PreprocessOptional(double_t const& value) { return value; }
             inline nonstd::optional<std::string> PreprocessOptional(std::string value) {
               return value.empty() ? nonstd::optional<std::string>() : nonstd::optional<std::string>(std::move(value));
             }

--- a/src/Tools/CodeGenerator/Plugins/OnnxRuntimePluginImpl/StandardCustomStructInfo.py
+++ b/src/Tools/CodeGenerator/Plugins/OnnxRuntimePluginImpl/StandardCustomStructInfo.py
@@ -63,6 +63,12 @@ class StandardCustomStructInfo(CustomStructInfo):
     # ----------------------------------------------------------------------
     @Interface.override
     def GetDefOutputStatementsConstraintsAndSuffix(self):
+        # ----------------------------------------------------------------------
+        def ToOrtTypeString(value):
+            return value.replace("std::", "").replace("_t", "")
+
+        # ----------------------------------------------------------------------
+
         output_statements = []
 
         for index, member in enumerate(self._custom_struct.members):
@@ -79,7 +85,7 @@ class StandardCustomStructInfo(CustomStructInfo):
             output_statements,
             OrderedDict(
                 [
-                    (k, ["{}".format(re.sub("_t$","", v.replace("std::", "")))])
+                    (k, [ToOrtTypeString(v)])
                     for k,
                     v in six.iteritems(self._template_to_types)
                 ],
@@ -102,7 +108,7 @@ class StandardCustomStructInfo(CustomStructInfo):
                         [
                             "ctx.getOutputType({index})->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_{type});".format(
                                 index=index,
-                                type=re.sub("_t$","", member.type.replace("std::", "")).upper(),
+                                type=ToOrtTypeString(member.type).upper(),
                             ) for index,
                             member in enumerate(self._custom_struct.members)
                         ],
@@ -130,7 +136,7 @@ class StandardCustomStructInfo(CustomStructInfo):
             initialize_statements_part2.append(
                 "{type}* {name}_data({name}_tensor->MutableData<{type}>());".format(
                     name=member.name,
-                    type=member.type if "string" in member.type else member.type.replace("std::", ""),
+                    type=member.type,
                 ),
             )
 
@@ -156,5 +162,5 @@ class StandardCustomStructInfo(CustomStructInfo):
                 """,
             ).format(
                 transformer_name=transformer_name,
-            )]
+            )],
         )

--- a/src/Tools/CodeGenerator/Plugins/SharedLibraryPlugin.py
+++ b/src/Tools/CodeGenerator/Plugins/SharedLibraryPlugin.py
@@ -102,14 +102,14 @@ def _CreateInterfaceSubstitutionDict(item, c_data):
         type_desc = ""
         cpp_template_suffix = ""
     else:
-        template_desc = template.replace("std::", "")
-
-        suffix = "_{}_".format(template_desc)
-        type_desc = " <{}>".format(template_desc)
+        suffix = "_{}_".format(template)
+        type_desc = " <{}>".format(template)
         if item.is_output_a_template:
-            cpp_template_suffix = "<{}>".format(template + ", " + item.output_type)
+            cpp_template_suffix = "<{}>".format(
+                c_data.InputTypeInfoFactory.CppType + ", " + item.output_type,
+            )
         else:
-            cpp_template_suffix = "<{}>".format(template)
+            cpp_template_suffix = "<{}>".format(c_data.InputTypeInfoFactory.CppType)
 
     # ----------------------------------------------------------------------
     def ToParamsString(params, arg_desc):
@@ -409,9 +409,7 @@ def _GenerateHeaderFile(output_dir, items, c_data_items, output_stream):
         custom_struct_flag = False
 
         for item, c_data in zip(items, c_data_items):
-            template = (
-                item.template.replace("std::", "") if hasattr(item, "template") else None
-            )
+            template = item.template if hasattr(item, "template") else None
 
             d = _CreateInterfaceSubstitutionDict(item, c_data)
 
@@ -595,9 +593,7 @@ def _GenerateCppFile(output_dir, items, c_data_items, output_stream):
         )
 
         for item, c_data in zip(items, c_data_items):
-            template = (
-                item.template.replace("std::", "") if hasattr(item, "template") else None
-            )
+            template = item.template if hasattr(item, "template") else None
 
             d = _CreateInterfaceSubstitutionDict(item, c_data)
 
@@ -734,7 +730,7 @@ def _GenerateCppFile(output_dir, items, c_data_items, output_stream):
                     }}
 
                     """,
-                ).format(**d),
+                ).format(**d)
             )
 
             # IsTrainingComplete
@@ -843,7 +839,7 @@ def _GenerateCppFile(output_dir, items, c_data_items, output_stream):
                     FEATURIZER_LIBRARY_API bool {name}{suffix}OnDataCompleted(/*in*/ {name}{suffix}EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {{
                         {method_prefix}
                             if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
-                            
+
                             Microsoft::Featurizer::Featurizers::{estimator_name}{cpp_template_suffix} & estimator(*g_pointerTable.Get<Microsoft::Featurizer::Featurizers::{estimator_name}{cpp_template_suffix}>(reinterpret_cast<size_t>(pHandle)));
 
                             estimator.on_data_completed();
@@ -851,7 +847,7 @@ def _GenerateCppFile(output_dir, items, c_data_items, output_stream):
                     }}
 
                     """,
-                ).format(**d),
+                ).format(**d)
             )
 
             # CompleteTraining

--- a/src/Tools/CodeGenerator/Plugins/SharedLibraryPluginImpl/ScalarTypeInfoFactories.py
+++ b/src/Tools/CodeGenerator/Plugins/SharedLibraryPluginImpl/ScalarTypeInfoFactories.py
@@ -44,7 +44,7 @@ class _ScalarTypeInfoFactory(TypeInfoFactory):
             invocation_statement = invocation_template.format(
                 "{name} != nullptr ? *{name} : Microsoft::Featurizer::Traits<{cpp_type}>::CreateNullValue()".format(
                     name=arg_name,
-                    cpp_type=cls.TypeName,
+                    cpp_type=cls.CppType,
                 ),
             )
 
@@ -84,7 +84,7 @@ class _ScalarTypeInfoFactory(TypeInfoFactory):
                 """,
             ).format(
                 name=arg_name,
-                cpp_type=cls.TypeName,
+                cpp_type=cls.CppType,
             )
 
             invocation_statement = invocation_template.format(
@@ -164,71 +164,81 @@ class _ScalarTypeInfoFactory(TypeInfoFactory):
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class Int8TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::int8_t")
+    TypeName                                = Interface.DerivedProperty("int8")
     CType                                   = Interface.DerivedProperty("int8_t")
+    CppType                                 = Interface.DerivedProperty("std::int8_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class Int16TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::int16_t")
+    TypeName                                = Interface.DerivedProperty("int16")
     CType                                   = Interface.DerivedProperty("int16_t")
+    CppType                                 = Interface.DerivedProperty("std::int16_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class Int32TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::int32_t")
+    TypeName                                = Interface.DerivedProperty("int32")
     CType                                   = Interface.DerivedProperty("int32_t")
+    CppType                                 = Interface.DerivedProperty("std::int32_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class Int64TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::int64_t")
+    TypeName                                = Interface.DerivedProperty("int64")
     CType                                   = Interface.DerivedProperty("int64_t")
+    CppType                                 = Interface.DerivedProperty("std::int64_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class UInt8TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::uint8_t")
+    TypeName                                = Interface.DerivedProperty("uint8")
     CType                                   = Interface.DerivedProperty("uint8_t")
+    CppType                                 = Interface.DerivedProperty("std::uint8_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class UInt16TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::uint16_t")
+    TypeName                                = Interface.DerivedProperty("uint16")
     CType                                   = Interface.DerivedProperty("uint16_t")
+    CppType                                 = Interface.DerivedProperty("std::uint16_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class UInt32TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::uint32_t")
+    TypeName                                = Interface.DerivedProperty("uint32")
     CType                                   = Interface.DerivedProperty("uint32_t")
+    CppType                                 = Interface.DerivedProperty("std::uint32_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class UInt64TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::uint64_t")
+    TypeName                                = Interface.DerivedProperty("uint64")
     CType                                   = Interface.DerivedProperty("uint64_t")
+    CppType                                 = Interface.DerivedProperty("std::uint64_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class FloatTypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::float_t")
+    TypeName                                = Interface.DerivedProperty("float")
     CType                                   = Interface.DerivedProperty("float")
+    CppType                                 = Interface.DerivedProperty("std::float_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class DoubleTypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::double_t")
+    TypeName                                = Interface.DerivedProperty("double")
     CType                                   = Interface.DerivedProperty("double")
+    CppType                                 = Interface.DerivedProperty("std::double_t")
 
 
 # ----------------------------------------------------------------------
@@ -236,3 +246,4 @@ class DoubleTypeInfoFactory(_ScalarTypeInfoFactory):
 class BoolTypeInfoFactory(_ScalarTypeInfoFactory):
     TypeName                                = Interface.DerivedProperty("bool")
     CType                                   = Interface.DerivedProperty("bool")
+    CppType                                 = Interface.DerivedProperty("bool")

--- a/src/Tools/CodeGenerator/Plugins/SharedLibraryPluginImpl/StringTypeInfoFactory.py
+++ b/src/Tools/CodeGenerator/Plugins/SharedLibraryPluginImpl/StringTypeInfoFactory.py
@@ -25,7 +25,8 @@ class StringTypeInfoFactory(TypeInfoFactory):
     # |  Public Types
     # |
     # ----------------------------------------------------------------------
-    TypeName                                = Interface.DerivedProperty("std::string")
+    TypeName                                = Interface.DerivedProperty("string")
+    CppType                                 = Interface.DerivedProperty("std::string")
 
     # ----------------------------------------------------------------------
     # |

--- a/src/Tools/CodeGenerator/Plugins/SharedLibraryPluginImpl/StructTypeInfoFactories.py
+++ b/src/Tools/CodeGenerator/Plugins/SharedLibraryPluginImpl/StructTypeInfoFactories.py
@@ -130,15 +130,18 @@ class _StructTypeInfoFactory(TypeInfoFactory):
 @Interface.staticderived
 class TimePointTypeInfoFactory(_StructTypeInfoFactory):
     TypeName                                = Interface.DerivedProperty("TimePoint")
+    CppType                                 = Interface.DerivedProperty("TimePoint")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class OneHotStructTypeInfoFactory(_StructTypeInfoFactory):
     TypeName                                = Interface.DerivedProperty("OneHotStruct")
+    CppType                                 = Interface.DerivedProperty("OneHotStruct")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class HashOneHotVectorizerStructTypeInfoFactory(_StructTypeInfoFactory):
     TypeName                                = Interface.DerivedProperty("HashOneHotVectorizerStruct")
+    CppType                                 = Interface.DerivedProperty("HashOneHotVectorizerStruct")

--- a/src/Tools/CodeGenerator/Plugins/SharedLibraryPluginImpl/TypeInfoFactory.py
+++ b/src/Tools/CodeGenerator/Plugins/SharedLibraryPluginImpl/TypeInfoFactory.py
@@ -46,6 +46,11 @@ class TypeInfoFactory(Interface.Interface):
         """Name of the type"""
         raise Exception("Abstract property")
 
+    @Interface.abstractproperty
+    def CppType(self):
+        """C++ type"""
+        raise Exception("Abstract property")
+
     # ----------------------------------------------------------------------
     # |
     # |  Public Methods

--- a/src/Tools/CodeGenerator/Plugins/SharedLibraryTestsPlugin.py
+++ b/src/Tools/CodeGenerator/Plugins/SharedLibraryTestsPlugin.py
@@ -110,11 +110,11 @@ def _GenerateHeaderFile(output_dir, items, all_type_info_data, output_stream):
         for item, type_info_data in zip(items, all_type_info_data):
             template = getattr(item, "template", None)
             if template:
-                template_desc = template.replace("std::", "")
-
-                suffix = "_{}_".format(template_desc)
-                type_desc = " <{}>".format(template_desc)
-                cpp_template_suffix = "<{}>".format(template)
+                suffix = "_{}_".format(template)
+                type_desc = " <{}>".format(template)
+                cpp_template_suffix = "<{}>".format(
+                    type_info_data.InputTypeInfoFactory.CppType,
+                )
             else:
                 suffix = "_"
                 type_desc = ""

--- a/src/Tools/CodeGenerator/Plugins/SharedLibraryTestsPluginImpl/ScalarTypeInfoFactories.py
+++ b/src/Tools/CodeGenerator/Plugins/SharedLibraryTestsPluginImpl/ScalarTypeInfoFactories.py
@@ -23,16 +23,6 @@ class _ScalarTypeInfoFactory(TypeInfoFactory):
 
     # ----------------------------------------------------------------------
     # |
-    # |  Public Properties
-    # |
-    # ----------------------------------------------------------------------
-    @Interface.abstractproperty
-    def CppType(self):
-        """C++ type"""
-        raise Exception("Abstract property")
-
-    # ----------------------------------------------------------------------
-    # |
     # |  Public Methods
     # |
     # ----------------------------------------------------------------------
@@ -77,71 +67,71 @@ class _ScalarTypeInfoFactory(TypeInfoFactory):
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class Int8TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::int8_t")
-    CppType                                 = Interface.DerivedProperty("int8_t")
+    TypeName                                = Interface.DerivedProperty("int8")
+    CppType                                 = Interface.DerivedProperty("std::int8_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class Int16TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::int16_t")
-    CppType                                 = Interface.DerivedProperty("int16_t")
+    TypeName                                = Interface.DerivedProperty("int16")
+    CppType                                 = Interface.DerivedProperty("std::int16_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class Int32TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::int32_t")
-    CppType                                 = Interface.DerivedProperty("int32_t")
+    TypeName                                = Interface.DerivedProperty("int32")
+    CppType                                 = Interface.DerivedProperty("std::int32_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class Int64TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::int64_t")
-    CppType                                 = Interface.DerivedProperty("int64_t")
+    TypeName                                = Interface.DerivedProperty("int64")
+    CppType                                 = Interface.DerivedProperty("std::int64_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class UInt8TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::uint8_t")
-    CppType                                 = Interface.DerivedProperty("uint8_t")
+    TypeName                                = Interface.DerivedProperty("uint8")
+    CppType                                 = Interface.DerivedProperty("std::uint8_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class UInt16TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::uint16_t")
-    CppType                                 = Interface.DerivedProperty("uint16_t")
+    TypeName                                = Interface.DerivedProperty("uint16")
+    CppType                                 = Interface.DerivedProperty("std::uint16_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class UInt32TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::uint32_t")
-    CppType                                 = Interface.DerivedProperty("uint32_t")
+    TypeName                                = Interface.DerivedProperty("uint32")
+    CppType                                 = Interface.DerivedProperty("std::uint32_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class UInt64TypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::uint64_t")
-    CppType                                 = Interface.DerivedProperty("uint64_t")
+    TypeName                                = Interface.DerivedProperty("uint64")
+    CppType                                 = Interface.DerivedProperty("std::uint64_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class FloatTypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::float_t")
-    CppType                                 = Interface.DerivedProperty("float")
+    TypeName                                = Interface.DerivedProperty("float")
+    CppType                                 = Interface.DerivedProperty("std::float_t")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class DoubleTypeInfoFactory(_ScalarTypeInfoFactory):
-    TypeName                                = Interface.DerivedProperty("std::double_t")
-    CppType                                 = Interface.DerivedProperty("double")
+    TypeName                                = Interface.DerivedProperty("double")
+    CppType                                 = Interface.DerivedProperty("std::double_t")
 
 
 # ----------------------------------------------------------------------

--- a/src/Tools/CodeGenerator/Plugins/SharedLibraryTestsPluginImpl/StringTypeInfoFactory.py
+++ b/src/Tools/CodeGenerator/Plugins/SharedLibraryTestsPluginImpl/StringTypeInfoFactory.py
@@ -25,7 +25,8 @@ class StringTypeInfoFactory(TypeInfoFactory):
     # |  Public Types
     # |
     # ----------------------------------------------------------------------
-    TypeName                                = Interface.DerivedProperty("std::string")
+    TypeName                                = Interface.DerivedProperty("string")
+    CppType                                 = Interface.DerivedProperty("std::string")
 
     # ----------------------------------------------------------------------
     # |

--- a/src/Tools/CodeGenerator/Plugins/SharedLibraryTestsPluginImpl/StructTypeInfoFactories.py
+++ b/src/Tools/CodeGenerator/Plugins/SharedLibraryTestsPluginImpl/StructTypeInfoFactories.py
@@ -77,15 +77,18 @@ class _StructTypeInfoFactory(TypeInfoFactory):
 @Interface.staticderived
 class TimePointTypeInfoFactory(_StructTypeInfoFactory):
     TypeName                                = Interface.DerivedProperty("TimePoint")
+    CppType                                 = Interface.DerivedProperty("TimePoint")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class OneHotStructTypeInfoFactory(_StructTypeInfoFactory):
     TypeName                                = Interface.DerivedProperty("OneHotStruct")
+    CppType                                 = Interface.DerivedProperty("OneHotStruct")
 
 
 # ----------------------------------------------------------------------
 @Interface.staticderived
 class HashOneHotVectorizerStructTypeInfoFactory(_StructTypeInfoFactory):
     TypeName                                = Interface.DerivedProperty("HashOneHotVectorizerStruct")
+    CppType                                 = Interface.DerivedProperty("HashOneHotVectorizerStruct")

--- a/src/Tools/CodeGenerator/Plugins/SharedLibraryTestsPluginImpl/TypeInfoFactory.py
+++ b/src/Tools/CodeGenerator/Plugins/SharedLibraryTestsPluginImpl/TypeInfoFactory.py
@@ -57,6 +57,11 @@ class TypeInfoFactory(Interface.Interface):
         """Name of the type"""
         raise Exception("Abstract property")
 
+    @Interface.abstractproperty
+    def CppType(self):
+        """C++ type"""
+        raise Exception("Abstract property")
+
     # ----------------------------------------------------------------------
     # |
     # |  Public Methods


### PR DESCRIPTION
This change is in preparation for the introduction of the datetime type and the corresponding code generator plugins.

- ONNX Runtime types now use "_t" types where the macro generates C++ code (this wasn't applied consistently before this change)