### PR TITLE
fix pipeline publish

### DIFF
--- a/CI/Publish.yaml
+++ b/CI/Publish.yaml
@@ -22,7 +22,7 @@ stages:
           job_name: AuzreUpload_Job
           job_display_name: "Azure Upload"
           operating_system: Windows
-          custom_checkout: 
+          custom_checkout: none
           steps:
             - template: "Publish.azureupload_steps_template.yaml"
               parameters:
@@ -39,7 +39,7 @@ stages:
           job_name: NuGet_Job
           job_display_name: "NuGet Packages"
           operating_system: Windows
-          custom_checkout: 
+          custom_checkout: none
           steps:
             - template: "Publish.nuget_steps_template.yaml"
               parameters:
@@ -60,7 +60,7 @@ stages:
           job_name: GitTag_Job
           job_display_name: "Tag Git Sources (for release builds)"
           operating_system: Windows
-          custom_checkout: 
+          custom_checkout: none
           steps:
             - template: "Publish.tagsources_steps_template.yaml"
               parameters:

--- a/CI/Publish.yaml
+++ b/CI/Publish.yaml
@@ -22,7 +22,7 @@ stages:
           job_name: AuzreUpload_Job
           job_display_name: "Azure Upload"
           operating_system: Windows
-          custom_checkout: ""
+          custom_checkout: 
           steps:
             - template: "Publish.azureupload_steps_template.yaml"
               parameters:
@@ -39,7 +39,7 @@ stages:
           job_name: NuGet_Job
           job_display_name: "NuGet Packages"
           operating_system: Windows
-          custom_checkout: ""
+          custom_checkout: 
           steps:
             - template: "Publish.nuget_steps_template.yaml"
               parameters:
@@ -60,7 +60,7 @@ stages:
           job_name: GitTag_Job
           job_display_name: "Tag Git Sources (for release builds)"
           operating_system: Windows
-          custom_checkout: ""
+          custom_checkout: 
           steps:
             - template: "Publish.tagsources_steps_template.yaml"
               parameters:

--- a/CI/Publish.yaml
+++ b/CI/Publish.yaml
@@ -22,8 +22,7 @@ stages:
           job_name: AuzreUpload_Job
           job_display_name: "Azure Upload"
           operating_system: Windows
-          custom_checkout:
-            - checkout: none
+          custom_checkout: ""
           steps:
             - template: "Publish.azureupload_steps_template.yaml"
               parameters:
@@ -40,8 +39,7 @@ stages:
           job_name: NuGet_Job
           job_display_name: "NuGet Packages"
           operating_system: Windows
-          custom_checkout:
-            - checkout: none
+          custom_checkout: ""
           steps:
             - template: "Publish.nuget_steps_template.yaml"
               parameters:
@@ -62,8 +60,7 @@ stages:
           job_name: GitTag_Job
           job_display_name: "Tag Git Sources (for release builds)"
           operating_system: Windows
-          custom_checkout:
-            - checkout: none
+          custom_checkout: ""
           steps:
             - template: "Publish.tagsources_steps_template.yaml"
               parameters:

--- a/CI/templates/_job_template.yaml
+++ b/CI/templates/_job_template.yaml
@@ -35,7 +35,8 @@ jobs:
                 clean: All
 
               steps:
-                - ${{ parameters.custom_checkout }}
+                - ${{ if not(eq(parameters.custom_checkout, 'none')) }}:
+                  - ${{ parameters.custom_checkout }}
                 - ${{ parameters.steps }}
 
         - ${{ if eq(parameters.operating_system, 'Linux') }}:
@@ -61,7 +62,8 @@ jobs:
                   #   clean: All
 
                   steps:
-                    - ${{ parameters.custom_checkout }}
+                    - ${{ if not(eq(parameters.custom_checkout, 'none')) }}:
+                      - ${{ parameters.custom_checkout }}
                     - ${{ parameters.steps }}
 
             - ${{ if not(eq(parameters.agent_pool_container, '')) }}:
@@ -88,7 +90,8 @@ jobs:
                   #   clean: All
 
                   steps:
-                    - ${{ parameters.custom_checkout }}
+                    - ${{ if not(eq(parameters.custom_checkout, 'none')) }}:
+                      - ${{ parameters.custom_checkout }}
                     - ${{ parameters.steps }}
 
     - ${{ if not(eq(parameters.agent_pool_is_custom, 'true')) }}:
@@ -105,7 +108,8 @@ jobs:
                 clean: All
 
               steps:
-                - ${{ parameters.custom_checkout }}
+                - ${{ if not(eq(parameters.custom_checkout, 'none')) }}:
+                  - ${{ parameters.custom_checkout }}
                 - ${{ parameters.steps }}
 
         - ${{ if not(eq(parameters.agent_pool_container, '')) }}:
@@ -123,5 +127,6 @@ jobs:
                 clean: All
 
               steps:
-                - ${{ parameters.custom_checkout }}
+                - ${{ if not(eq(parameters.custom_checkout, 'none')) }}:
+                  - ${{ parameters.custom_checkout }}
                 - ${{ parameters.steps }}

--- a/CI/templates/_job_template.yaml
+++ b/CI/templates/_job_template.yaml
@@ -36,7 +36,7 @@ jobs:
 
               steps:
                 - ${{ if not(eq(parameters.custom_checkout, 'none')) }}:
-                  - ${{ parameters.custom_checkout }}
+                    - ${{ parameters.custom_checkout }}
                 - ${{ parameters.steps }}
 
         - ${{ if eq(parameters.operating_system, 'Linux') }}:
@@ -63,7 +63,7 @@ jobs:
 
                   steps:
                     - ${{ if not(eq(parameters.custom_checkout, 'none')) }}:
-                      - ${{ parameters.custom_checkout }}
+                        - ${{ parameters.custom_checkout }}
                     - ${{ parameters.steps }}
 
             - ${{ if not(eq(parameters.agent_pool_container, '')) }}:
@@ -91,7 +91,7 @@ jobs:
 
                   steps:
                     - ${{ if not(eq(parameters.custom_checkout, 'none')) }}:
-                      - ${{ parameters.custom_checkout }}
+                        - ${{ parameters.custom_checkout }}
                     - ${{ parameters.steps }}
 
     - ${{ if not(eq(parameters.agent_pool_is_custom, 'true')) }}:
@@ -109,7 +109,7 @@ jobs:
 
               steps:
                 - ${{ if not(eq(parameters.custom_checkout, 'none')) }}:
-                  - ${{ parameters.custom_checkout }}
+                    - ${{ parameters.custom_checkout }}
                 - ${{ parameters.steps }}
 
         - ${{ if not(eq(parameters.agent_pool_container, '')) }}:
@@ -128,5 +128,5 @@ jobs:
 
               steps:
                 - ${{ if not(eq(parameters.custom_checkout, 'none')) }}:
-                  - ${{ parameters.custom_checkout }}
+                    - ${{ parameters.custom_checkout }}
                 - ${{ parameters.steps }}


### PR DESCRIPTION
It looks like azure pipeline doesn't like multi-definition of checkout. Rewrite the checkout option so that the _job_template.yaml will add no steps when checkout parameter is set to "none"