### PR TITLE
Fix Median in TimeSeriesImputer

### DIFF
--- a/src/Featurizers/UnitTests/TimeSeriesImputerFeaturizer_UnitTest.cpp
+++ b/src/Featurizers/UnitTests/TimeSeriesImputerFeaturizer_UnitTest.cpp
@@ -514,7 +514,8 @@ TEST_CASE("ColumnImputation (Median): 1 grain (EmptyRow, EmptyRow)") {
     std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
     std::vector<std::tuple<bool,std::chrono::system_clock::time_point, std::vector<std::string>, std::vector<nonstd::optional<std::string>>>> output = {
                     std::make_tuple(false,GetTimePoint(now,0), std::vector<std::string>{"a"}, std::vector<nonstd::optional<std::string>>{"15.500000","50.000000"}),
-                    std::make_tuple(false,GetTimePoint(now,1), std::vector<std::string>{"a"}, std::vector<nonstd::optional<std::string>>{"15.500000","50.000000"})
+                    std::make_tuple(true,GetTimePoint(now,1), std::vector<std::string>{"a"}, std::vector<nonstd::optional<std::string>>{"15.500000","50.000000"}),
+                    std::make_tuple(false,GetTimePoint(now,2), std::vector<std::string>{"a"}, std::vector<nonstd::optional<std::string>>{"15.500000","50.000000"})
                 };
     CHECK(Test({
                     {
@@ -525,7 +526,7 @@ TEST_CASE("ColumnImputation (Median): 1 grain (EmptyRow, EmptyRow)") {
                 },
                 {
                     std::make_tuple(GetTimePoint(now,0), std::vector<std::string>{"a"}, std::vector<nonstd::optional<std::string>>{nonstd::optional<std::string>{},nonstd::optional<std::string>{}}),
-                    std::make_tuple(GetTimePoint(now,1), std::vector<std::string>{"a"}, std::vector<nonstd::optional<std::string>>{nonstd::optional<std::string>{},nonstd::optional<std::string>{}})
+                    std::make_tuple(GetTimePoint(now,2), std::vector<std::string>{"a"}, std::vector<nonstd::optional<std::string>>{nonstd::optional<std::string>{},nonstd::optional<std::string>{}})
                 },{NS::TypeId::Float64,NS::TypeId::Float64}, false, NS::Featurizers::Components::TimeSeriesImputeStrategy::Median) == output);
     }
 

--- a/src/SharedLibrary/IntegrationTests/SharedLibrary_TSIFeaturizer_IntegrationTest.cpp
+++ b/src/SharedLibrary/IntegrationTests/SharedLibrary_TSIFeaturizer_IntegrationTest.cpp
@@ -15,27 +15,27 @@
 namespace NS = Microsoft::Featurizer;
 using system_clock                          = std::chrono::system_clock;
 
-TEST_CASE("End-to-end") {
+TEST_CASE("End-to-end Median") {
     std::vector<TypeId>                                                     keyIds{ StringId, StringId };
     std::vector<TypeId>                                                     dataIds{ Int32Id, Float32Id, UInt32Id };
     TimeSeriesImputerFeaturizer_BinaryArchive_EstimatorHandle *             estimatorHandle(nullptr);
     ErrorInfoHandle *                                                       pErrorInfo(nullptr);
-    bool suppressErrors(false);
+    bool suppressErrors(true);
 
-    CHECK(
+    REQUIRE(
         TimeSeriesImputerFeaturizer_BinaryArchive_CreateEstimator(
             keyIds.data(),
             keyIds.size(),
             dataIds.data(),
             dataIds.size(),
-            Forward,
+            Median,
             &suppressErrors,
             &estimatorHandle,
             &pErrorInfo
         )
     );
-    CHECK(estimatorHandle != nullptr);
-    CHECK(pErrorInfo == nullptr);
+    REQUIRE(estimatorHandle != nullptr);
+    REQUIRE(pErrorInfo == nullptr);
 
     system_clock::time_point                originalTimePoint(system_clock::from_time_t(time_t(217081624)));
 
@@ -83,8 +83,8 @@ TEST_CASE("End-to-end") {
     // Complete training
     while(true) {
         FitResult                               fitResult;
-
-        CHECK(
+        TrainingState                           trainingState(0);
+        REQUIRE(
             TimeSeriesImputerFeaturizer_BinaryArchive_Fit(
                 estimatorHandle,
                 bad1,
@@ -92,10 +92,10 @@ TEST_CASE("End-to-end") {
                 &pErrorInfo
             )
         );
-        CHECK(fitResult == Continue);
-        CHECK(pErrorInfo == nullptr);
+        REQUIRE(fitResult == Continue);
+        REQUIRE(pErrorInfo == nullptr);
 
-        CHECK(
+        REQUIRE(
             TimeSeriesImputerFeaturizer_BinaryArchive_Fit(
                 estimatorHandle,
                 bad2,
@@ -103,23 +103,29 @@ TEST_CASE("End-to-end") {
                 &pErrorInfo
             )
         );
-        CHECK(fitResult == Continue);
-        CHECK(pErrorInfo == nullptr);
+        REQUIRE(fitResult == Continue);
+        REQUIRE(pErrorInfo == nullptr);
 
-        TimeSeriesImputerFeaturizer_BinaryArchive_CompleteTraining(estimatorHandle, &pErrorInfo);
-        break;
+        REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_OnDataCompleted(estimatorHandle, &pErrorInfo));
+
+        TimeSeriesImputerFeaturizer_BinaryArchive_GetState(estimatorHandle,  &trainingState, &pErrorInfo);
+
+        if(trainingState != Training)
+            break;
     }
+
+    TimeSeriesImputerFeaturizer_BinaryArchive_CompleteTraining(estimatorHandle, &pErrorInfo);
 
     // Create Transformer
     TimeSeriesImputerFeaturizer_BinaryArchive_TransformerHandle *           transformerHandle(nullptr);
 
-    CHECK(TimeSeriesImputerFeaturizer_BinaryArchive_CreateTransformerFromEstimator(estimatorHandle, &transformerHandle, &pErrorInfo));
-    CHECK(transformerHandle != nullptr);
-    CHECK(pErrorInfo == nullptr);
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_CreateTransformerFromEstimator(estimatorHandle, &transformerHandle, &pErrorInfo));
+    REQUIRE(transformerHandle != nullptr);
+    REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the Estimator
-    CHECK(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyEstimator(estimatorHandle, &pErrorInfo));
-    CHECK(pErrorInfo == nullptr);
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyEstimator(estimatorHandle, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
 
     // Transform
     NS::Archive::ByteArray const            bytes3(
@@ -130,7 +136,7 @@ TEST_CASE("End-to-end") {
             NS::Traits<std::string>::serialize(archive, "Hello");
             NS::Traits<std::string>::serialize(archive, "World");
             NS::Traits<typename NS::Traits<std::int32_t>::nullable_type>::serialize(archive, 18);
-            NS::Traits<typename NS::Traits<std::float_t>::nullable_type>::serialize(archive, 3.0f);
+            NS::Traits<typename NS::Traits<std::float_t>::nullable_type>::serialize(archive, std::nanf("1"));
             NS::Traits<typename NS::Traits<std::uint32_t>::nullable_type>::serialize(archive, static_cast<std::uint32_t>(123456));
 
             return archive.commit();
@@ -145,7 +151,7 @@ TEST_CASE("End-to-end") {
     BinaryArchiveData *                     pTransformResults(nullptr);
     size_t                                  cNumResults(0);
 
-    CHECK(
+    REQUIRE(
         TimeSeriesImputerFeaturizer_BinaryArchive_Transform(
             transformerHandle,
             bad3,
@@ -154,7 +160,7 @@ TEST_CASE("End-to-end") {
             &pErrorInfo
         )
     );
-    CHECK(pErrorInfo == nullptr);
+    REQUIRE(pErrorInfo == nullptr);
     REQUIRE(pTransformResults != nullptr);
     REQUIRE(cNumResults != 0);
 
@@ -177,16 +183,16 @@ TEST_CASE("End-to-end") {
 #   pragma clang diagnostic ignored "-Wfloat-equal"
 #endif
 
-        CHECK(rowAdded == false);
-        CHECK(timePoint == originalTimePoint);
-        CHECK(key1 == "Hello");
-        CHECK(key2 == "World");
+        REQUIRE(rowAdded == false);
+        REQUIRE(timePoint == originalTimePoint);
+        REQUIRE(key1 == "Hello");
+        REQUIRE(key2 == "World");
         REQUIRE(NS::Traits<decltype(data1)>::IsNull(data1) == false);
-        CHECK(NS::Traits<decltype(data1)>::GetNullableValue(data1) == 18);
+        REQUIRE(NS::Traits<decltype(data1)>::GetNullableValue(data1) == 18);
         REQUIRE(NS::Traits<decltype(data2)>::IsNull(data2) == false);
-        CHECK(NS::Traits<decltype(data2)>::GetNullableValue(data2) == 3.0f);
+        REQUIRE(NS::Traits<decltype(data2)>::GetNullableValue(data2) == 3.0f);
         REQUIRE(NS::Traits<decltype(data3)>::IsNull(data3) == false);
-        CHECK(NS::Traits<decltype(data3)>::GetNullableValue(data3) == 123456);
+        REQUIRE(NS::Traits<decltype(data3)>::GetNullableValue(data3) == 123456);
 
 
 #if (defined __clang__)
@@ -195,47 +201,47 @@ TEST_CASE("End-to-end") {
     }
 
     // Destroy the data
-    CHECK(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformedData(pTransformResults, cNumResults, &pErrorInfo));
-    CHECK(pErrorInfo == nullptr);
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformedData(pTransformResults, cNumResults, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
 
     // Flush
     pTransformResults = nullptr;
     cNumResults = 0;
 
-    CHECK(TimeSeriesImputerFeaturizer_BinaryArchive_Flush(transformerHandle, &pTransformResults, &cNumResults, &pErrorInfo));
-    CHECK(pErrorInfo == nullptr);
-    CHECK(pTransformResults == nullptr);
-    CHECK(cNumResults == 0);
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_Flush(transformerHandle, &pTransformResults, &cNumResults, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
+    REQUIRE(pTransformResults == nullptr);
+    REQUIRE(cNumResults == 0);
 
     // Destroy the flush results (even though they are empty)
-    CHECK(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformedData(pTransformResults, cNumResults, &pErrorInfo));
-    CHECK(pErrorInfo == nullptr);
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformedData(pTransformResults, cNumResults, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
 
     // Create serialized data
     unsigned char const *                   pSavedData(nullptr);
     size_t                                  cSavedData(0);
 
-    CHECK(TimeSeriesImputerFeaturizer_BinaryArchive_CreateTransformerSaveData(transformerHandle, &pSavedData, &cSavedData, &pErrorInfo));
-    CHECK(pErrorInfo == nullptr);
-    CHECK(pSavedData != nullptr);
-    CHECK(cSavedData != 0);
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_CreateTransformerSaveData(transformerHandle, &pSavedData, &cSavedData, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
+    REQUIRE(pSavedData != nullptr);
+    REQUIRE(cSavedData != 0);
 
     // Destroy the transformer
-    CHECK(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformer(transformerHandle, &pErrorInfo));
-    CHECK(pErrorInfo == nullptr);
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformer(transformerHandle, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
 
     // Create a transformer based on the serialize data
     TimeSeriesImputerFeaturizer_BinaryArchive_TransformerHandle *           otherTransformerHandle(nullptr);
 
-    CHECK(TimeSeriesImputerFeaturizer_BinaryArchive_CreateTransformerFromSavedData(pSavedData, cSavedData, &otherTransformerHandle, &pErrorInfo));
-    CHECK(pErrorInfo == nullptr);
-    CHECK(otherTransformerHandle != nullptr);
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_CreateTransformerFromSavedData(pSavedData, cSavedData, &otherTransformerHandle, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
+    REQUIRE(otherTransformerHandle != nullptr);
 
     // Destroy the serialized data
-    CHECK(DestroyTransformerSaveData(pSavedData, cSavedData, &pErrorInfo));
-    CHECK(pErrorInfo == nullptr);
+    REQUIRE(DestroyTransformerSaveData(pSavedData, cSavedData, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
 
-    CHECK(
+    REQUIRE(
         TimeSeriesImputerFeaturizer_BinaryArchive_Transform(
             otherTransformerHandle,
             bad1,
@@ -245,7 +251,7 @@ TEST_CASE("End-to-end") {
         )
     );
 
-    CHECK(pErrorInfo == nullptr);
+    REQUIRE(pErrorInfo == nullptr);
     REQUIRE(pTransformResults != nullptr);
     REQUIRE(cNumResults != 0);
 
@@ -268,16 +274,16 @@ TEST_CASE("End-to-end") {
 #   pragma clang diagnostic ignored "-Wfloat-equal"
 #endif
 
-        CHECK(rowAdded == false);
-        CHECK(timePoint == originalTimePoint);
-        CHECK(key1 == "Hello");
-        CHECK(key2 == "World");
+        REQUIRE(rowAdded == false);
+        REQUIRE(timePoint == originalTimePoint);
+        REQUIRE(key1 == "Hello");
+        REQUIRE(key2 == "World");
         REQUIRE(NS::Traits<decltype(data1)>::IsNull(data1) == false);
-        CHECK(NS::Traits<decltype(data1)>::GetNullableValue(data1) == 18);
+        REQUIRE(NS::Traits<decltype(data1)>::GetNullableValue(data1) == 18);
         REQUIRE(NS::Traits<decltype(data2)>::IsNull(data2) == false);
-        CHECK(NS::Traits<decltype(data2)>::GetNullableValue(data2) == 2.0f);
+        REQUIRE(NS::Traits<decltype(data2)>::GetNullableValue(data2) == 2.0f);
         REQUIRE(NS::Traits<decltype(data3)>::IsNull(data3) == false);
-        CHECK(NS::Traits<decltype(data3)>::GetNullableValue(data3) == 123456);
+        REQUIRE(NS::Traits<decltype(data3)>::GetNullableValue(data3) == 123456);
 
 
 #if (defined __clang__)
@@ -286,10 +292,10 @@ TEST_CASE("End-to-end") {
     }
 
     // Destroy the data
-    CHECK(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformedData(pTransformResults, cNumResults, &pErrorInfo));
-    CHECK(pErrorInfo == nullptr);
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformedData(pTransformResults, cNumResults, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
 
     // Destroy the transformer
-    CHECK(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformer(otherTransformerHandle, &pErrorInfo));
-    CHECK(pErrorInfo == nullptr);
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformer(otherTransformerHandle, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
 }

--- a/src/SharedLibrary/IntegrationTests/SharedLibrary_TSIFeaturizer_IntegrationTest.cpp
+++ b/src/SharedLibrary/IntegrationTests/SharedLibrary_TSIFeaturizer_IntegrationTest.cpp
@@ -15,7 +15,7 @@
 namespace NS = Microsoft::Featurizer;
 using system_clock                          = std::chrono::system_clock;
 
-TEST_CASE("End-to-end Median") {
+TEST_CASE("End-to-end-Median") {
     std::vector<TypeId>                                                     keyIds{ StringId, StringId };
     std::vector<TypeId>                                                     dataIds{ Int32Id, Float32Id, UInt32Id };
     TimeSeriesImputerFeaturizer_BinaryArchive_EstimatorHandle *             estimatorHandle(nullptr);
@@ -202,6 +202,369 @@ TEST_CASE("End-to-end Median") {
 
     // Destroy the data
     REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformedData(pTransformResults, cNumResults, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
+
+    // Flush
+    pTransformResults = nullptr;
+    cNumResults = 0;
+
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_Flush(transformerHandle, &pTransformResults, &cNumResults, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
+    REQUIRE(pTransformResults == nullptr);
+    REQUIRE(cNumResults == 0);
+
+    // Destroy the flush results (even though they are empty)
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformedData(pTransformResults, cNumResults, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
+
+    // Create serialized data
+    unsigned char const *                   pSavedData(nullptr);
+    size_t                                  cSavedData(0);
+
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_CreateTransformerSaveData(transformerHandle, &pSavedData, &cSavedData, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
+    REQUIRE(pSavedData != nullptr);
+    REQUIRE(cSavedData != 0);
+
+    // Destroy the transformer
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformer(transformerHandle, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
+
+    // Create a transformer based on the serialize data
+    TimeSeriesImputerFeaturizer_BinaryArchive_TransformerHandle *           otherTransformerHandle(nullptr);
+
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_CreateTransformerFromSavedData(pSavedData, cSavedData, &otherTransformerHandle, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
+    REQUIRE(otherTransformerHandle != nullptr);
+
+    // Destroy the serialized data
+    REQUIRE(DestroyTransformerSaveData(pSavedData, cSavedData, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
+
+    REQUIRE(
+        TimeSeriesImputerFeaturizer_BinaryArchive_Transform(
+            otherTransformerHandle,
+            bad1,
+            &pTransformResults,
+            &cNumResults,
+            &pErrorInfo
+        )
+    );
+
+    REQUIRE(pErrorInfo == nullptr);
+    REQUIRE(pTransformResults != nullptr);
+    REQUIRE(cNumResults != 0);
+
+    // Deserialize the data
+    REQUIRE(cNumResults == 1);
+
+    {
+        NS::Archive                         archive(pTransformResults->pBuffer, pTransformResults->cBuffer);
+
+        bool const                                                          rowAdded(NS::Traits<bool>::deserialize(archive));
+        system_clock::time_point const                                      timePoint(NS::Traits<system_clock::time_point>::deserialize(archive));
+        std::string const                                                   key1(NS::Traits<std::string>::deserialize(archive));
+        std::string const                                                   key2(NS::Traits<std::string>::deserialize(archive));
+        typename NS::Traits<int32_t>::nullable_type const                   data1(NS::Traits<typename NS::Traits<int32_t>::nullable_type>::deserialize(archive));
+        typename NS::Traits<float_t>::nullable_type const                   data2(NS::Traits<typename NS::Traits<float_t>::nullable_type>::deserialize(archive));
+        typename NS::Traits<uint32_t>::nullable_type const                  data3(NS::Traits<typename NS::Traits<uint32_t>::nullable_type>::deserialize(archive));
+
+#if (defined __clang__)
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wfloat-equal"
+#endif
+
+        REQUIRE(rowAdded == false);
+        REQUIRE(timePoint == originalTimePoint);
+        REQUIRE(key1 == "Hello");
+        REQUIRE(key2 == "World");
+        REQUIRE(NS::Traits<decltype(data1)>::IsNull(data1) == false);
+        REQUIRE(NS::Traits<decltype(data1)>::GetNullableValue(data1) == 18);
+        REQUIRE(NS::Traits<decltype(data2)>::IsNull(data2) == false);
+        REQUIRE(NS::Traits<decltype(data2)>::GetNullableValue(data2) == 2.0f);
+        REQUIRE(NS::Traits<decltype(data3)>::IsNull(data3) == false);
+        REQUIRE(NS::Traits<decltype(data3)>::GetNullableValue(data3) == 123456);
+
+
+#if (defined __clang__)
+#   pragma clang diagnostic pop
+#endif
+    }
+
+    // Destroy the data
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformedData(pTransformResults, cNumResults, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
+
+    // Destroy the transformer
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformer(otherTransformerHandle, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
+}
+
+TEST_CASE("End-to-end-Forward") {
+    std::vector<TypeId>                                                     keyIds{ StringId, StringId };
+    std::vector<TypeId>                                                     dataIds{ Int32Id, Float32Id, UInt32Id };
+    TimeSeriesImputerFeaturizer_BinaryArchive_EstimatorHandle *             estimatorHandle(nullptr);
+    ErrorInfoHandle *                                                       pErrorInfo(nullptr);
+    bool suppressErrors(true);
+
+    REQUIRE(
+        TimeSeriesImputerFeaturizer_BinaryArchive_CreateEstimator(
+            keyIds.data(),
+            keyIds.size(),
+            dataIds.data(),
+            dataIds.size(),
+            Forward,
+            &suppressErrors,
+            &estimatorHandle,
+            &pErrorInfo
+        )
+    );
+    REQUIRE(estimatorHandle != nullptr);
+    REQUIRE(pErrorInfo == nullptr);
+
+    system_clock::time_point                originalTimePoint(system_clock::from_time_t(time_t(217081624)));
+
+    // Fit
+    NS::Archive::ByteArray const            bytes1(
+        [&originalTimePoint](void) {
+            NS::Archive                         archive;
+
+            NS::Traits<system_clock::time_point>::serialize(archive, originalTimePoint);
+            NS::Traits<std::string>::serialize(archive, "Hello");
+            NS::Traits<std::string>::serialize(archive, "World");
+            NS::Traits<typename NS::Traits<std::int32_t>::nullable_type>::serialize(archive, 18);
+            NS::Traits<typename NS::Traits<std::float_t>::nullable_type>::serialize(archive, 2.0f);
+            NS::Traits<typename NS::Traits<std::uint32_t>::nullable_type>::serialize(archive, static_cast<std::uint32_t>(123456));
+
+            return archive.commit();
+        }()
+    );
+
+    BinaryArchiveData                       bad1;
+
+    bad1.pBuffer = bytes1.data();
+    bad1.cBuffer = bytes1.size();
+
+    NS::Archive::ByteArray const            bytes2(
+        [&originalTimePoint](void) {
+            NS::Archive                         archive;
+
+            NS::Traits<system_clock::time_point>::serialize(archive, originalTimePoint + std::chrono::seconds(2));
+            NS::Traits<std::string>::serialize(archive, "Hello");
+            NS::Traits<std::string>::serialize(archive, "World");
+            NS::Traits<typename NS::Traits<std::int32_t>::nullable_type>::serialize(archive, 18);
+            NS::Traits<typename NS::Traits<std::float_t>::nullable_type>::serialize(archive, 4.0f);
+            NS::Traits<typename NS::Traits<std::uint32_t>::nullable_type>::serialize(archive, static_cast<std::uint32_t>(123456));
+
+            return archive.commit();
+        }()
+    );
+
+    BinaryArchiveData                       bad2;
+
+    bad2.pBuffer = bytes2.data();
+    bad2.cBuffer = bytes2.size();
+
+    // Complete training
+    while(true) {
+        FitResult                               fitResult;
+        TrainingState                           trainingState(0);
+        REQUIRE(
+            TimeSeriesImputerFeaturizer_BinaryArchive_Fit(
+                estimatorHandle,
+                bad1,
+                &fitResult,
+                &pErrorInfo
+            )
+        );
+        REQUIRE(fitResult == Continue);
+        REQUIRE(pErrorInfo == nullptr);
+
+        REQUIRE(
+            TimeSeriesImputerFeaturizer_BinaryArchive_Fit(
+                estimatorHandle,
+                bad2,
+                &fitResult,
+                &pErrorInfo
+            )
+        );
+        REQUIRE(fitResult == Continue);
+        REQUIRE(pErrorInfo == nullptr);
+
+        REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_OnDataCompleted(estimatorHandle, &pErrorInfo));
+
+        TimeSeriesImputerFeaturizer_BinaryArchive_GetState(estimatorHandle,  &trainingState, &pErrorInfo);
+
+        if(trainingState != Training)
+            break;
+    }
+
+    TimeSeriesImputerFeaturizer_BinaryArchive_CompleteTraining(estimatorHandle, &pErrorInfo);
+
+    // Create Transformer
+    TimeSeriesImputerFeaturizer_BinaryArchive_TransformerHandle *           transformerHandle(nullptr);
+
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_CreateTransformerFromEstimator(estimatorHandle, &transformerHandle, &pErrorInfo));
+    REQUIRE(transformerHandle != nullptr);
+    REQUIRE(pErrorInfo == nullptr);
+
+    // Destroy the Estimator
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyEstimator(estimatorHandle, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
+
+    // Transform
+    NS::Archive::ByteArray const            bytes3(
+        [&originalTimePoint](void) {
+            NS::Archive                         archive;
+
+            NS::Traits<system_clock::time_point>::serialize(archive, originalTimePoint);
+            NS::Traits<std::string>::serialize(archive, "Hello");
+            NS::Traits<std::string>::serialize(archive, "World");
+            NS::Traits<typename NS::Traits<std::int32_t>::nullable_type>::serialize(archive, 18);
+            NS::Traits<typename NS::Traits<std::float_t>::nullable_type>::serialize(archive, 3.0f);
+            NS::Traits<typename NS::Traits<std::uint32_t>::nullable_type>::serialize(archive, static_cast<std::uint32_t>(123456));
+
+            return archive.commit();
+        }()
+    );
+
+    BinaryArchiveData                       bad3;
+
+    bad3.pBuffer = bytes3.data();
+    bad3.cBuffer = bytes3.size();
+
+    BinaryArchiveData *                     pTransformResults(nullptr);
+    size_t                                  cNumResults(0);
+
+    REQUIRE(
+        TimeSeriesImputerFeaturizer_BinaryArchive_Transform(
+            transformerHandle,
+            bad3,
+            &pTransformResults,
+            &cNumResults,
+            &pErrorInfo
+        )
+    );
+    REQUIRE(pErrorInfo == nullptr);
+    REQUIRE(pTransformResults != nullptr);
+    REQUIRE(cNumResults != 0);
+
+    // Deserialize the data
+    REQUIRE(cNumResults == 1);
+
+    {
+        NS::Archive                         archive(pTransformResults->pBuffer, pTransformResults->cBuffer);
+
+        bool const                                                          rowAdded(NS::Traits<bool>::deserialize(archive));
+        system_clock::time_point const                                      timePoint(NS::Traits<system_clock::time_point>::deserialize(archive));
+        std::string const                                                   key1(NS::Traits<std::string>::deserialize(archive));
+        std::string const                                                   key2(NS::Traits<std::string>::deserialize(archive));
+        typename NS::Traits<int32_t>::nullable_type const                   data1(NS::Traits<typename NS::Traits<int32_t>::nullable_type>::deserialize(archive));
+        typename NS::Traits<float_t>::nullable_type const                   data2(NS::Traits<typename NS::Traits<float_t>::nullable_type>::deserialize(archive));
+        typename NS::Traits<uint32_t>::nullable_type const                  data3(NS::Traits<typename NS::Traits<uint32_t>::nullable_type>::deserialize(archive));
+
+#if (defined __clang__)
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wfloat-equal"
+#endif
+
+        REQUIRE(rowAdded == false);
+        REQUIRE(timePoint == originalTimePoint);
+        REQUIRE(key1 == "Hello");
+        REQUIRE(key2 == "World");
+        REQUIRE(NS::Traits<decltype(data1)>::IsNull(data1) == false);
+        REQUIRE(NS::Traits<decltype(data1)>::GetNullableValue(data1) == 18);
+        REQUIRE(NS::Traits<decltype(data2)>::IsNull(data2) == false);
+        REQUIRE(NS::Traits<decltype(data2)>::GetNullableValue(data2) == 3.0f);
+        REQUIRE(NS::Traits<decltype(data3)>::IsNull(data3) == false);
+        REQUIRE(NS::Traits<decltype(data3)>::GetNullableValue(data3) == 123456);
+
+
+#if (defined __clang__)
+#   pragma clang diagnostic pop
+#endif
+    }
+
+    // Destroy the data
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformedData(pTransformResults, cNumResults, &pErrorInfo));
+    REQUIRE(pErrorInfo == nullptr);
+
+    // Exercise Forward Fill Functionality
+    // Transform
+    NS::Archive::ByteArray const            bytes4(
+        [&originalTimePoint](void) {
+            NS::Archive                         archive;
+
+            NS::Traits<system_clock::time_point>::serialize(archive, originalTimePoint);
+            NS::Traits<std::string>::serialize(archive, "Hello");
+            NS::Traits<std::string>::serialize(archive, "World");
+            NS::Traits<typename NS::Traits<std::int32_t>::nullable_type>::serialize(archive, nonstd::optional<std::int32_t>());
+            NS::Traits<typename NS::Traits<std::float_t>::nullable_type>::serialize(archive, std::nanf("1"));
+            NS::Traits<typename NS::Traits<std::uint32_t>::nullable_type>::serialize(archive, nonstd::optional<std::uint32_t>());
+
+            return archive.commit();
+        }()
+    );
+
+    BinaryArchiveData                       bad4;
+
+    bad4.pBuffer = bytes4.data();
+    bad4.cBuffer = bytes4.size();
+
+    BinaryArchiveData *                     pTransformResults2(nullptr);
+    size_t                                  cNumResults2(0);
+
+    REQUIRE(
+        TimeSeriesImputerFeaturizer_BinaryArchive_Transform(
+            transformerHandle,
+            bad4,
+            &pTransformResults2,
+            &cNumResults2,
+            &pErrorInfo
+        )
+    );
+    REQUIRE(pErrorInfo == nullptr);
+    REQUIRE(pTransformResults2 != nullptr);
+    REQUIRE(cNumResults2 != 0);
+
+    // Deserialize the data
+    REQUIRE(cNumResults2 == 1);
+
+    {
+        NS::Archive                         archive(pTransformResults2->pBuffer, pTransformResults2->cBuffer);
+
+        bool const                                                          rowAdded(NS::Traits<bool>::deserialize(archive));
+        system_clock::time_point const                                      timePoint(NS::Traits<system_clock::time_point>::deserialize(archive));
+        std::string const                                                   key1(NS::Traits<std::string>::deserialize(archive));
+        std::string const                                                   key2(NS::Traits<std::string>::deserialize(archive));
+        typename NS::Traits<int32_t>::nullable_type const                   data1(NS::Traits<typename NS::Traits<int32_t>::nullable_type>::deserialize(archive));
+        typename NS::Traits<float_t>::nullable_type const                   data2(NS::Traits<typename NS::Traits<float_t>::nullable_type>::deserialize(archive));
+        typename NS::Traits<uint32_t>::nullable_type const                  data3(NS::Traits<typename NS::Traits<uint32_t>::nullable_type>::deserialize(archive));
+
+#if (defined __clang__)
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wfloat-equal"
+#endif
+
+        REQUIRE(rowAdded == false);
+        REQUIRE(timePoint == originalTimePoint);
+        REQUIRE(key1 == "Hello");
+        REQUIRE(key2 == "World");
+        REQUIRE(NS::Traits<decltype(data1)>::IsNull(data1) == false);
+        REQUIRE(NS::Traits<decltype(data1)>::GetNullableValue(data1) == 18);
+        REQUIRE(NS::Traits<decltype(data2)>::IsNull(data2) == false);
+        REQUIRE(NS::Traits<decltype(data2)>::GetNullableValue(data2) == 3.0f);
+        REQUIRE(NS::Traits<decltype(data3)>::IsNull(data3) == false);
+        REQUIRE(NS::Traits<decltype(data3)>::GetNullableValue(data3) == 123456);
+
+
+#if (defined __clang__)
+#   pragma clang diagnostic pop
+#endif
+    }
+
+    // Destroy the data
+    REQUIRE(TimeSeriesImputerFeaturizer_BinaryArchive_DestroyTransformedData(pTransformResults2, cNumResults2, &pErrorInfo));
     REQUIRE(pErrorInfo == nullptr);
 
     // Flush

--- a/src/SharedLibrary/SharedLibrary_TimeSeriesImputerFeaturizer.cpp
+++ b/src/SharedLibrary/SharedLibrary_TimeSeriesImputerFeaturizer.cpp
@@ -312,6 +312,48 @@ FEATURIZER_LIBRARY_API bool TimeSeriesImputerFeaturizer_BinaryArchive_FitBuffer(
     }
 }
 
+FEATURIZER_LIBRARY_API bool TimeSeriesImputerFeaturizer_BinaryArchive_GetState(/*in*/ TimeSeriesImputerFeaturizer_BinaryArchive_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo) {
+        if(ppErrorInfo == nullptr)
+        return false;
+
+    try {
+        *ppErrorInfo = nullptr;
+
+        if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
+
+        EstimatorMemory &                   memory(*g_pointerTable.Get<EstimatorMemory>(reinterpret_cast<size_t>(pHandle)));
+
+        *pState = static_cast<TrainingState>(memory.Estimator.get_state());
+
+        return true;
+    }
+    catch(std::exception const &ex) {
+        *ppErrorInfo = CreateErrorInfo(ex);
+        return false;
+    }
+}
+
+FEATURIZER_LIBRARY_API bool TimeSeriesImputerFeaturizer_BinaryArchive_OnDataCompleted(/*in*/ TimeSeriesImputerFeaturizer_BinaryArchive_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo){
+    if(ppErrorInfo == nullptr)
+        return false;
+
+    try {
+        *ppErrorInfo = nullptr;
+
+        if(pHandle == nullptr) throw std::invalid_argument("'pHandle' is null");
+
+        EstimatorMemory &                   memory(*g_pointerTable.Get<EstimatorMemory>(reinterpret_cast<size_t>(pHandle)));
+
+        memory.Estimator.on_data_completed();
+
+        return true;
+    }
+    catch(std::exception const &ex) {
+        *ppErrorInfo = CreateErrorInfo(ex);
+        return false;
+    }
+}
+
 FEATURIZER_LIBRARY_API bool TimeSeriesImputerFeaturizer_BinaryArchive_CompleteTraining(/*in*/ TimeSeriesImputerFeaturizer_BinaryArchive_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo) {
     if(ppErrorInfo == nullptr)
         return false;

--- a/src/SharedLibrary/SharedLibrary_TimeSeriesImputerFeaturizer.h
+++ b/src/SharedLibrary/SharedLibrary_TimeSeriesImputerFeaturizer.h
@@ -46,8 +46,10 @@ FEATURIZER_LIBRARY_API bool TimeSeriesImputerFeaturizer_BinaryArchive_CreateEsti
 FEATURIZER_LIBRARY_API bool TimeSeriesImputerFeaturizer_BinaryArchive_DestroyEstimator(/*in*/ TimeSeriesImputerFeaturizer_BinaryArchive_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 FEATURIZER_LIBRARY_API bool TimeSeriesImputerFeaturizer_BinaryArchive_IsTrainingComplete(/*in*/ TimeSeriesImputerFeaturizer_BinaryArchive_EstimatorHandle *pHandle, /*out*/ bool *pIsTrainingComplete, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool TimeSeriesImputerFeaturizer_BinaryArchive_GetState(/*in*/ TimeSeriesImputerFeaturizer_BinaryArchive_EstimatorHandle *pHandle, /*out*/ TrainingState *pState, /*out*/ ErrorInfoHandle **ppErrorInfo);
 FEATURIZER_LIBRARY_API bool TimeSeriesImputerFeaturizer_BinaryArchive_Fit(/*in*/ TimeSeriesImputerFeaturizer_BinaryArchive_EstimatorHandle *pHandle, /*in*/ BinaryArchiveData data, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
 FEATURIZER_LIBRARY_API bool TimeSeriesImputerFeaturizer_BinaryArchive_FitBuffer(/*in*/ TimeSeriesImputerFeaturizer_BinaryArchive_EstimatorHandle *pHandle, /*in*/ BinaryArchiveData const *pData, /*in*/ std::size_t numDataElements, /*out*/ FitResult *pFitResult, /*out*/ ErrorInfoHandle **ppErrorInfo);
+FEATURIZER_LIBRARY_API bool TimeSeriesImputerFeaturizer_BinaryArchive_OnDataCompleted(/*in*/ TimeSeriesImputerFeaturizer_BinaryArchive_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 FEATURIZER_LIBRARY_API bool TimeSeriesImputerFeaturizer_BinaryArchive_CompleteTraining(/*in*/ TimeSeriesImputerFeaturizer_BinaryArchive_EstimatorHandle *pHandle, /*out*/ ErrorInfoHandle **ppErrorInfo);
 
 /* Inference Methods */


### PR DESCRIPTION
This PR adds in the new `TimeSeriesImputerFeaturizer_BinaryArchive_GetState` and `TimeSeriesImputerFeaturizer_BinaryArchive_OnDataCompleted` methods resolving the issues with TimeSeriesImputer. It also adds another integration test to check for this in the future.