### PR TITLE
_ctor not marked inline produces double definition.

### DIFF
--- a/src/Featurizers/Components/StandardDeviationEstimator.h
+++ b/src/Featurizers/Components/StandardDeviationEstimator.h
@@ -169,7 +169,7 @@ public:
 // |
 // ----------------------------------------------------------------------
 
-StandardDeviationAnnotationData::StandardDeviationAnnotationData(long double standard_deviation, std::uint64_t count) :
+inline StandardDeviationAnnotationData::StandardDeviationAnnotationData(long double standard_deviation, std::uint64_t count) :
     StandardDeviation(std::move(standard_deviation)),
     Count(std::move(count)) {
         if (StandardDeviation < 0) {


### PR DESCRIPTION
Fix it. One should either mark things inline if they are in the headers OR put them into .CC files.