### PR TITLE
Only update generated files if the content has changed

### DIFF
--- a/src/Tools/CodeGenerator/Plugin.py
+++ b/src/Tools/CodeGenerator/Plugin.py
@@ -51,7 +51,7 @@ class Plugin(Interface.Interface):
     # ----------------------------------------------------------------------
     @staticmethod
     @Interface.abstractmethod
-    def Generate(global_custom_structs, global_custom_enums, data, output_dir, status_stream):
+    def Generate(open_file_func, global_custom_structs, global_custom_enums, data, output_dir, status_stream):
         """Generates content based on the provided data. Returns a result code."""
         raise Exception("Abstract method")
 

--- a/src/Tools/CodeGenerator/Plugins/MLNetPlugin.py
+++ b/src/Tools/CodeGenerator/Plugins/MLNetPlugin.py
@@ -43,7 +43,7 @@ class Plugin(PluginBase):
     # |  Methods
     @staticmethod
     @Interface.override
-    def Generate(global_custom_structs, global_custom_enums, data, output_dir, status_stream):
+    def Generate(open_file_func, global_custom_structs, global_custom_enums, data, output_dir, status_stream):
         result_code = 0
 
         status_stream.write("Preprocessing data for ML.NET...")
@@ -74,6 +74,7 @@ class Plugin(PluginBase):
                     )
                     with dm.stream.DoneManager() as this_dm:
                         this_dm.result = func(
+                            open_file_func,
                             output_dir,
                             items,
                             items_csharp_data,
@@ -107,13 +108,13 @@ def _FillList(item, status_stream, unsupported_types, global_custom_structs, glo
             raise e
 
 
-def _GenerateCSharpFile(output_dir, items, csharp_data_items, output_stream):
+def _GenerateCSharpFile(open_file_func, output_dir, items, csharp_data_items, output_stream):
     baseName = items[0].name.replace("Featurizer", "")
     transformerName = baseName + "Transformer"
     estimatorName = baseName + "Estimator"
     entrypointName = baseName + "Entrypoint"
 
-    with open(os.path.join(output_dir, "{}.cs".format(items[0].name)), "w") as f:
+    with open_file_func(os.path.join(output_dir, "{}.cs".format(items[0].name)), "w") as f:
         f.write(
             textwrap.dedent(
                 """\

--- a/src/Tools/CodeGenerator/Plugins/OnnxRuntimePlugin.py
+++ b/src/Tools/CodeGenerator/Plugins/OnnxRuntimePlugin.py
@@ -43,7 +43,7 @@ class Plugin(PluginBase):
     # |  Methods
     @staticmethod
     @Interface.override
-    def Generate(global_custom_structs, global_custom_enums, data, output_dir, status_stream):
+    def Generate(open_file_func, global_custom_structs, global_custom_enums, data, output_dir, status_stream):
         result_code = 0
 
         status_stream.write("Preprocessing data...")
@@ -127,6 +127,7 @@ class Plugin(PluginBase):
                 this_dm.stream.write(desc)
                 with this_dm.stream.DoneManager() as dm:
                     dm.result = func(
+                        open_file_func,
                         output_dir,
                         data,
                         type_mappings,
@@ -158,6 +159,7 @@ class Plugin(PluginBase):
                         input_type_mapping, output_type_mapping = type_mapping
 
                         this_dm.result = func(
+                            open_file_func,
                             output_dir,
                             items,
                             input_type_mapping,
@@ -222,6 +224,7 @@ def _GetCppTypeMapping(
 
 # ----------------------------------------------------------------------
 def _GenerateGlobalKernels(
+    open_file_func,
     output_dir,
     all_items,
     all_type_mappings,
@@ -231,7 +234,7 @@ def _GenerateGlobalKernels(
     output_dir = os.path.join(output_dir, "featurizers_ops")
     FileSystem.MakeDirs(output_dir)
 
-    with open(os.path.join(output_dir, "cpu_featurizers_kernels.h"), "w") as f:
+    with open_file_func(os.path.join(output_dir, "cpu_featurizers_kernels.h"), "w") as f:
         f.write(
             textwrap.dedent(
                 """\
@@ -269,7 +272,7 @@ def _GenerateGlobalKernels(
         )
         continue
 
-    with open(os.path.join(output_dir, "cpu_featurizers_kernels.cc"), "w") as f:
+    with open_file_func(os.path.join(output_dir, "cpu_featurizers_kernels.cc"), "w") as f:
         f.write(
             textwrap.dedent(
                 """\
@@ -318,6 +321,7 @@ def _GenerateGlobalKernels(
 
 # ----------------------------------------------------------------------
 def _GenerateGlobalDefs(
+    open_file_func,
     output_dir,
     all_items,
     all_type_mappings,
@@ -327,7 +331,7 @@ def _GenerateGlobalDefs(
     output_dir = os.path.join(output_dir, "core", "graph", "featurizers_ops")
     FileSystem.MakeDirs(output_dir)
 
-    with open(os.path.join(output_dir, "featurizers_defs.h"), "w") as f:
+    with open_file_func(os.path.join(output_dir, "featurizers_defs.h"), "w") as f:
         f.write(
             textwrap.dedent(
                 """\
@@ -634,7 +638,7 @@ def _GenerateGlobalDefs(
             ),
         )
 
-    with open(os.path.join(output_dir, "featurizers_defs.cc"), "w") as f:
+    with open_file_func(os.path.join(output_dir, "featurizers_defs.cc"), "w") as f:
         f.write(
             textwrap.dedent(
                 """\
@@ -711,6 +715,7 @@ def _GenerateGlobalDefs(
 
 # ----------------------------------------------------------------------
 def _GenerateKernel(
+    open_file_func,
     output_dir,
     items,
     input_type_mappings,
@@ -941,7 +946,7 @@ def _GenerateKernel(
         ),
     )
 
-    with open(
+    with open_file_func(
         os.path.join(
             output_dir,
             "{}.cc".format(

--- a/src/Tools/CodeGenerator/Plugins/SharedLibraryPlugin.py
+++ b/src/Tools/CodeGenerator/Plugins/SharedLibraryPlugin.py
@@ -44,6 +44,7 @@ class Plugin(PluginBase):
     @staticmethod
     @Interface.override
     def Generate(
+        open_file_func,
         global_custom_structs,
         global_custom_enums,
         data,
@@ -63,7 +64,7 @@ class Plugin(PluginBase):
 
         status_stream.write("Generating Common Files...")
         with status_stream.DoneManager() as this_dm:
-            this_dm.result = _GenerateCommonFiles(output_dir, this_dm.stream)
+            this_dm.result = _GenerateCommonFiles(open_file_func, output_dir, this_dm.stream)
             if this_dm.result != 0:
                 return this_dm.result
 
@@ -86,6 +87,7 @@ class Plugin(PluginBase):
                     )
                     with dm.stream.DoneManager() as this_dm:
                         this_dm.result = func(
+                            open_file_func,
                             output_dir,
                             items,
                             items_c_data,
@@ -145,8 +147,8 @@ def _CreateInterfaceSubstitutionDict(item, c_data):
 
 
 # ----------------------------------------------------------------------
-def _GenerateCommonFiles(output_dir, output_stream):
-    with open(os.path.join(output_dir, "SharedLibrary_Common.h"), "w") as f:
+def _GenerateCommonFiles(open_file_func, output_dir, output_stream):
+    with open_file_func(os.path.join(output_dir, "SharedLibrary_Common.h"), "w") as f:
         f.write(
             textwrap.dedent(
                 """\
@@ -290,7 +292,7 @@ def _GenerateCommonFiles(output_dir, output_stream):
             ),
         )
 
-    with open(os.path.join(output_dir, "SharedLibrary_Common.cpp"), "w") as f:
+    with open_file_func(os.path.join(output_dir, "SharedLibrary_Common.cpp"), "w") as f:
         f.write(
             textwrap.dedent(
                 """\
@@ -396,7 +398,7 @@ def _GenerateCommonFiles(output_dir, output_stream):
             ),
         )
 
-    with open(os.path.join(output_dir, "SharedLibrary_Common.hpp"), "w") as f:
+    with open_file_func(os.path.join(output_dir, "SharedLibrary_Common.hpp"), "w") as f:
         f.write(
             textwrap.dedent(
                 """\
@@ -436,7 +438,7 @@ def _GenerateCommonFiles(output_dir, output_stream):
             ),
         )
 
-    with open(os.path.join(output_dir, "SharedLibrary_PointerTable.h"), "w") as f:
+    with open_file_func(os.path.join(output_dir, "SharedLibrary_PointerTable.h"), "w") as f:
         f.write(
             textwrap.dedent(
                 """\
@@ -453,7 +455,7 @@ def _GenerateCommonFiles(output_dir, output_stream):
             ),
         )
 
-    with open(os.path.join(output_dir, "SharedLibrary_PointerTable.cpp"), "w") as f:
+    with open_file_func(os.path.join(output_dir, "SharedLibrary_PointerTable.cpp"), "w") as f:
         f.write(
             textwrap.dedent(
                 """\
@@ -481,8 +483,8 @@ def _GenerateCommonFiles(output_dir, output_stream):
 
 
 # ----------------------------------------------------------------------
-def _GenerateHeaderFile(output_dir, items, c_data_items, output_stream):
-    with open(
+def _GenerateHeaderFile(open_file_func, output_dir, items, c_data_items, output_stream):
+    with open_file_func(
         os.path.join(output_dir, "SharedLibrary_{}.h".format(items[0].name)),
         "w",
     ) as f:
@@ -686,8 +688,8 @@ def _GenerateHeaderFile(output_dir, items, c_data_items, output_stream):
 
 
 # ----------------------------------------------------------------------
-def _GenerateCppFile(output_dir, items, c_data_items, output_stream):
-    with open(
+def _GenerateCppFile(open_file_func, output_dir, items, c_data_items, output_stream):
+    with open_file_func(
         os.path.join(output_dir, "SharedLibrary_{}.cpp".format(items[0].name)),
         "w",
     ) as f:

--- a/src/Tools/CodeGenerator/Plugins/SharedLibraryTestsPlugin.py
+++ b/src/Tools/CodeGenerator/Plugins/SharedLibraryTestsPlugin.py
@@ -42,6 +42,7 @@ class Plugin(PluginBase):
     @staticmethod
     @Interface.override
     def Generate(
+        open_file_func,
         global_custom_structs,
         global_custom_enums,
         data,
@@ -74,6 +75,7 @@ class Plugin(PluginBase):
                     )
                     with dm.stream.DoneManager() as this_dm:
                         this_dm.result = func(
+                            open_file_func,
                             output_dir,
                             items,
                             items_type_info_data,
@@ -91,8 +93,8 @@ class Plugin(PluginBase):
 # ----------------------------------------------------------------------
 # ----------------------------------------------------------------------
 # ----------------------------------------------------------------------
-def _GenerateHeaderFile(output_dir, items, all_type_info_data, output_stream):
-    with open(
+def _GenerateHeaderFile(open_file_func, output_dir, items, all_type_info_data, output_stream):
+    with open_file_func(
         os.path.join(output_dir, "SharedLibraryTests_{}.h".format(items[0].name)),
         "w",
     ) as f:


### PR DESCRIPTION
Prevent full rebuilds after running code generation by only updating files that have actually changed.